### PR TITLE
Optional free camera: sub-tile rest offsets, pixel-perfect drag panning, scroll glide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Optional free camera (`smooth-movement camera on`, off by default): map scrolls
+  glide with an exponential catch-up, middle-mouse drag pans pixel-perfectly and
+  can rest between tiles, and `camera <fx> <fy>` sets a persistent sub-tile
+  offset. Render-only; the game's tile camera is untouched.
 - Fix sprites floating while the camera pans. The scroll variables change at input time but the
   viewport buffers shift on a later render frame, where the shift used to read as a real creature
   move and started a bogus slide across the screen. The buffer shift is now detected directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Follow the camera during a pan instead of resetting: in-flight movements are translated by the
+  map-scroll delta so sprites track the scrolled world rather than floating, and are dropped only
+  once they scroll off-screen. Zoom, Z-level, resize, and viewport changes still reset.
+
 ## 0.2.0 - 2026-07-28
 
 - Add a Windows x86-64 build for DFHack 53.15-r2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-- Follow the camera during a pan instead of resetting: in-flight movements are translated by the
-  map-scroll delta so sprites track the scrolled world rather than floating, and are dropped only
-  once they scroll off-screen. Zoom, Z-level, resize, and viewport changes still reset.
+- Fix sprites floating while the camera pans. The scroll variables change at input time but the
+  viewport buffers shift on a later render frame, where the shift used to read as a real creature
+  move and started a bogus slide across the screen. The buffer shift is now detected directly
+  (hypothesis-tested against the pending scroll delta): new-movement detection is suppressed while
+  a pan is pending, and in-flight movements are translated on the frame the shift lands so they
+  keep tracking the world. Zoom, Z-level, resize, and viewport changes still reset.
 
 ## 0.2.0 - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
 ## Behavior
 
 - Movement uses a 100 ms smoothstep interpolation.
-- Camera movement, zoom, Z-level changes, resize, and viewport changes reset
-  interpolation for one frame.
+- Camera panning is followed: in-flight interpolations are translated by the
+  scroll delta so sprites track the world, and drop once they scroll off-screen.
+- Zoom, Z-level changes, resize, and viewport changes reset interpolation for one
+  frame.
 - Ambiguous movements between identical sprites snap to the destination.
 - Main creature sprites crossing fire snap instead of being replayed over an
   unsafe layer reconstruction.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,33 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
   scroll delta so sprites track the world, and drop once they scroll off-screen.
 - Zoom, Z-level changes, resize, and viewport changes reset interpolation for one
   frame.
+
 - Ambiguous movements between identical sprites snap to the destination.
 - Main creature sprites crossing fire snap instead of being replayed over an
   unsafe layer reconstruction.
 - UI and menus are rendered after interpolated world sprites.
+
+## Free camera (optional, off by default)
+
+`smooth-movement camera on` unbinds the camera from the tile grid — render-only,
+the game's own tile camera (`window_x`/`window_y`) is untouched:
+
+- Map scrolls glide: the view exponentially catches up to the new position
+  (~100 ms) instead of stepping, drawing the world at sub-tile pixel offsets.
+  Jumps larger than 3 tiles (recenter, minimap) snap instantly.
+- Pixel-perfect middle-mouse drag panning: the view follows the mouse 1:1 and
+  rests wherever it is released — including half-way between tiles.
+- `smooth-movement camera <fx> <fy>` sets a persistent sub-tile offset directly
+  (positive = view east/south of the grid, up to ±0.99 tiles);
+  `smooth-movement camera reset` returns to the grid; `smooth-movement camera`
+  prints the state. Setting an offset implies `camera on`.
+- While the view rests off-grid, a sub-tile strip at one screen edge has no
+  viewport data and renders black, and the map rect is repainted every frame.
+  Whole tiles of offset are folded into the game camera automatically so the
+  strip never exceeds half a tile.
+
+Plain `enable smooth-movement` never activates the free camera; the toggle also
+resets to off whenever the plugin is re-enabled.
 
 ## Scope
 

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -37,7 +37,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.2.0+free-camera.2";
+constexpr const char *plugin_version="0.2.0";
 
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
@@ -84,6 +84,9 @@ bool has_pan_context=false;
 //                buffer data and stays black).
 //   transient -- the decaying scroll glide from before, in pixels, layered on top.
 // Render offset = transient + rest*tile. window_x/window_y remain the game's own tile camera.
+bool camera_enabled=false;                    // OFF by default: plain `enable smooth-movement`
+                                              // keeps upstream behavior (creature interpolation
+                                              // only); `smooth-movement camera on` opts in.
 constexpr int32_t camera_max_glide_tiles=3;   // per-jump: farther than this snaps instantly
 constexpr double camera_tau_ms=35.0;          // transient catch-up (~95% done after 100ms)
 double transient_x=0.0;                       // decaying glide offset, pixels
@@ -101,6 +104,9 @@ double drag_anchor_vy=0.0;
 int32_t drag_anchor_mx=0;                     // precise mouse at drag start, pixels
 int32_t drag_anchor_my=0;
 bool camera_was_offset=false;                 // edge-detects offset->0 for one cleanup redraw
+int32_t camera_prev_wx=0;                     // window-scroll observation baseline
+int32_t camera_prev_wy=0;
+bool camera_has_prev=false;
 
 double tile_px(const df::renderer_2d_base *renderer)
 {
@@ -144,6 +150,17 @@ void cancel_camera_transients()
 	self_scroll_x=0;
 	self_scroll_y=0;
 	drag_active=false;
+}
+
+void set_camera_enabled(bool enable)
+{
+	if(camera_enabled==enable)return;
+	camera_enabled=enable;
+	cancel_camera_transients();
+	rest_x=0.0;
+	rest_y=0.0;
+	camera_has_prev=false;   // fresh observation baseline; no phantom scroll on re-enable
+	// camera_was_offset stays: the render path issues one cleanup redraw if we were mid-offset.
 }
 
 // Fold whole tiles of rest into window_x/window_y so |rest| <= 0.5 (minimal edge strip). The
@@ -203,15 +220,14 @@ void update_camera(
 	const df::graphic_viewportst *vp,
 	uint32_t delta_ms)
 {
+	if(!camera_enabled)return;
 	const double tile=tile_px(renderer);
 	const int32_t wx=window_x?*window_x:0;
 	const int32_t wy=window_y?*window_y:0;
-	static int32_t prev_wx=0,prev_wy=0;
-	static bool has_prev=false;
-	if(has_prev&&(wx!=prev_wx||wy!=prev_wy))
+	if(camera_has_prev&&(wx!=camera_prev_wx||wy!=camera_prev_wy))
 		{
-		const int32_t dx=wx-prev_wx;
-		const int32_t dy=wy-prev_wy;
+		const int32_t dx=wx-camera_prev_wx;
+		const int32_t dy=wy-camera_prev_wy;
 		if((std::abs(dx)>camera_max_glide_tiles||std::abs(dy)>camera_max_glide_tiles)&&
 			!drag_active)
 			cancel_camera_transients();   // teleport-like jump (recenter/minimap): snap
@@ -222,9 +238,9 @@ void update_camera(
 			camera_pending_frames=0;
 			}
 		}
-	prev_wx=wx;
-	prev_wy=wy;
-	has_prev=true;
+	camera_prev_wx=wx;
+	camera_prev_wy=wy;
+	camera_has_prev=true;
 
 	if(camera_pending_dx!=0||camera_pending_dy!=0)
 		{
@@ -896,6 +912,8 @@ void reset_state()
 	cancel_camera_transients();
 	rest_x=0.0;
 	rest_y=0.0;
+	camera_enabled=false;
+	camera_has_prev=false;
 	camera_was_offset=false;
 }
 
@@ -909,15 +927,26 @@ command_result status_command(
 			"smooth-movement {}: {}\n",
 			plugin_version,
 			is_enabled?"enabled":"disabled");
-		out.print("camera offset: {:.3f} {:.3f} (tiles east/south of the grid)\n",
-			-rest_x,-rest_y);
+		out.print("free camera: {}, offset {:.3f} {:.3f} (tiles east/south of the grid)\n",
+			camera_enabled?"on":"off",-rest_x,-rest_y);
 		return CR_OK;
 		}
 	if(parameters[0]=="camera")
 		{
 		if(parameters.size()==1)
 			{
-			out.print("camera offset: {:.3f} {:.3f}\n",-rest_x,-rest_y);
+			out.print("free camera: {}, offset {:.3f} {:.3f}\n",
+				camera_enabled?"on":"off",-rest_x,-rest_y);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="on")
+			{
+			set_camera_enabled(true);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="off")
+			{
+			set_camera_enabled(false);
 			return CR_OK;
 			}
 		if(parameters.size()==2&&parameters[1]=="reset")
@@ -938,6 +967,7 @@ command_result status_command(
 					return CR_FAILURE;
 					}
 				// User-facing: positive = view sits east/south of the grid position.
+				set_camera_enabled(true);
 				rest_x=-fx;
 				rest_y=-fy;
 				normalize_rest();
@@ -960,7 +990,7 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 {
 	commands.emplace_back(
 		"smooth-movement",
-		"Smooth movement status / free-camera offset (camera <fx> <fy> | camera reset).",
+		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>.",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <set>
 #include <unordered_map>
@@ -33,7 +34,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.2.0";
+constexpr const char *plugin_version="0.2.0+smooth-camera";
 
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
@@ -45,11 +46,13 @@ constexpr const char *sdl_library="libSDL2-2.0.so.0";
 DFLibrary *sdl_handle=nullptr;
 using RenderCopyF=int (*)(SDL_Renderer *,SDL_Texture *,const SDL_Rect *,const SDL_FRect *);
 using RenderFillRect=int (*)(SDL_Renderer *,const SDL_Rect *);
+using RenderSetClipRect=int (*)(SDL_Renderer *,const SDL_Rect *);
 using GetRenderDrawColor=int (*)(SDL_Renderer *,Uint8 *,Uint8 *,Uint8 *,Uint8 *);
 using SetRenderDrawColor=int (*)(SDL_Renderer *,Uint8,Uint8,Uint8,Uint8);
 using GetTicks=Uint32 (*)();
 RenderCopyF render_copy_f=nullptr;
 RenderFillRect render_fill_rect=nullptr;
+RenderSetClipRect render_set_clip_rect=nullptr;
 GetRenderDrawColor get_render_draw_color=nullptr;
 SetRenderDrawColor set_render_draw_color=nullptr;
 GetTicks get_ticks=nullptr;
@@ -66,6 +69,123 @@ bool has_view_signature=false;
 int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
+
+// --- smooth camera glide -----------------------------------------------------------------------
+// The camera is visually unbound from the tile grid: when the map scrolls, the view keeps
+// rendering from the OLD position and exponentially catches up to the new one, drawing the world
+// at sub-tile pixel offsets in between. Pure render-state; the real camera (window_x/window_y)
+// is never touched.
+constexpr int32_t camera_max_glide_tiles=3;   // per-jump: farther than this snaps instantly
+constexpr double camera_tau_ms=35.0;          // catch-up time constant (~95% done after 100ms)
+double camera_offset_x=0.0;                   // remaining visual offset, in pixels
+double camera_offset_y=0.0;
+int32_t camera_pending_dx=0;                  // scroll delta announced but not yet in the buffers
+int32_t camera_pending_dy=0;
+int32_t camera_pending_frames=0;
+
+// Did the viewport buffers apply a scroll of (dwx,dwy) this frame? Tested on the BACKGROUND
+// layer: terrain is dense (nonzero nearly everywhere), so this works with no creatures on
+// screen. On a uniform screen the test can fire a frame early, but then a shifted render is
+// pixel-identical to an unshifted one, so the mistiming is invisible by construction.
+bool background_shift_matches(const df::graphic_viewportst *vp,int32_t dwx,int32_t dwy)
+{
+	int32_t considered=0;
+	int32_t matches=0;
+	for(int32_t x=0;x<vp->dim_x;++x)
+		{
+		const int32_t sx=x+dwx;
+		if(sx<0||sx>=vp->dim_x)continue;
+		for(int32_t y=0;y<vp->dim_y;++y)
+			{
+			const int32_t sy=y+dwy;
+			if(sy<0||sy>=vp->dim_y)continue;
+			const int32_t cur=vp->screentexpos_background[x*vp->dim_y+y];
+			if(cur==0)continue;
+			++considered;
+			if(vp->screentexpos_background_old[sx*vp->dim_y+sy]==cur)++matches;
+			}
+		}
+	return considered>0&&matches*5>=considered*3;
+}
+
+void cancel_camera_glide()
+{
+	camera_offset_x=0.0;
+	camera_offset_y=0.0;
+	camera_pending_dx=0;
+	camera_pending_dy=0;
+	camera_pending_frames=0;
+}
+
+// Track scroll changes, start the glide on the frame the buffers apply them, and decay the
+// offset toward zero. Called once per render frame.
+void update_camera(
+	df::renderer_2d_base *renderer,
+	const df::graphic_viewportst *vp,
+	uint32_t delta_ms)
+{
+	const int32_t wx=window_x?*window_x:0;
+	const int32_t wy=window_y?*window_y:0;
+	static int32_t prev_wx=0,prev_wy=0;
+	static bool has_prev=false;
+	if(has_prev&&(wx!=prev_wx||wy!=prev_wy))
+		{
+		const int32_t dx=wx-prev_wx;
+		const int32_t dy=wy-prev_wy;
+		if(std::abs(dx)>camera_max_glide_tiles||std::abs(dy)>camera_max_glide_tiles)
+			cancel_camera_glide();   // teleport-like jump: snap
+		else
+			{
+			camera_pending_dx+=dx;
+			camera_pending_dy+=dy;
+			camera_pending_frames=0;
+			}
+		}
+	prev_wx=wx;
+	prev_wy=wy;
+	has_prev=true;
+
+	if(camera_pending_dx!=0||camera_pending_dy!=0)
+		{
+		if(std::abs(camera_pending_dx)>camera_max_glide_tiles||
+			std::abs(camera_pending_dy)>camera_max_glide_tiles)
+			cancel_camera_glide();
+		else if(background_shift_matches(vp,camera_pending_dx,camera_pending_dy))
+			{
+			// The visual jump landed this frame: put the view back where it was and let the
+			// decay glide it to the new position.
+			const int32_t zoom=renderer->viewport_zoom_factor;
+			const double tile=double(zoom==128?32:std::max(1,zoom*32/128));
+			camera_offset_x+=camera_pending_dx*tile;
+			camera_offset_y+=camera_pending_dy*tile;
+			const double cap=tile*(camera_max_glide_tiles+0.5);
+			camera_offset_x=std::clamp(camera_offset_x,-cap,cap);
+			camera_offset_y=std::clamp(camera_offset_y,-cap,cap);
+			camera_pending_dx=0;
+			camera_pending_dy=0;
+			camera_pending_frames=0;
+			}
+		else if(++camera_pending_frames>4)
+			{
+			camera_pending_dx=0;
+			camera_pending_dy=0;
+			camera_pending_frames=0;
+			}
+		}
+
+	if(camera_offset_x!=0.0||camera_offset_y!=0.0)
+		{
+		const double k=std::exp(-double(delta_ms)/camera_tau_ms);
+		camera_offset_x*=k;
+		camera_offset_y*=k;
+		if(std::abs(camera_offset_x)<0.5&&std::abs(camera_offset_y)<0.5)
+			{
+			cancel_camera_glide();
+			// One engine-driven full redraw so the last sub-pixel-shifted frame is replaced.
+			if(gps!=nullptr)++gps->force_full_display_count;
+			}
+		}
+}
 
 constexpr uint32_t fire_bits=0x70000000U;
 
@@ -96,6 +216,7 @@ void update_visual_context(
 		{
 		++visual_context_revision;
 		previous_coverage.clear();
+		cancel_camera_glide();
 		}
 	previous_viewport=vp;
 	previous_view_signature=signature;
@@ -412,8 +533,14 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	animation_manager.end_frame();
 
 	if(vp==nullptr||!vp->flag.bits.active||
-		!animation_manager.requires_full_redraw()||
 		render_copy_f==nullptr||renderer->sdl_renderer==nullptr)
+		return;
+	if(render_set_clip_rect!=nullptr)
+		update_camera(renderer,vp,animation_manager.get_frame_delta_ms());
+	const int32_t glide_x=int32_t(std::lround(camera_offset_x));
+	const int32_t glide_y=int32_t(std::lround(camera_offset_y));
+	const bool glide=glide_x!=0||glide_y!=0;
+	if(!glide&&!animation_manager.requires_full_redraw())
 		return;
 
 	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);
@@ -432,14 +559,68 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 			upper_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
 		}
 
+	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
+	const int32_t zoom=renderer->viewport_zoom_factor;
+	const int32_t tile_size=zoom==128?32:std::max(1,zoom*32/128);
+
+	if(glide)
+		{
+		// Camera mid-glide: repaint the WHOLE map rect at the shifted origin so the world (and
+		// the creature proxies, which read origin at draw time) renders between tiles. The engine
+		// already drew this frame at the snapped position; everything here overdraws it, clipped
+		// to the map rect so shifted tiles never spill over the UI. The uncovered strip on the
+		// trailing edge stays black until the glide lands.
+		const SDL_Rect map_rect=
+			{
+			tile_pixel(vp->clipx[0],renderer->origin_x,zoom),
+			tile_pixel(vp->clipy[0],renderer->origin_y,zoom),
+			tile_pixel(vp->clipx[1]+1,renderer->origin_x,zoom)-
+				tile_pixel(vp->clipx[0],renderer->origin_x,zoom),
+			tile_pixel(vp->clipy[1]+1,renderer->origin_y,zoom)-
+				tile_pixel(vp->clipy[0],renderer->origin_y,zoom)
+			};
+		render_set_clip_rect(sdl_renderer,&map_rect);
+		Uint8 old_r=0,old_g=0,old_b=0,old_a=255;
+		get_render_draw_color(sdl_renderer,&old_r,&old_g,&old_b,&old_a);
+		set_render_draw_color(sdl_renderer,0,0,0,255);
+		render_fill_rect(sdl_renderer,&map_rect);
+		set_render_draw_color(sdl_renderer,old_r,old_g,old_b,old_a);
+
+		const int32_t saved_origin_x=renderer->origin_x;
+		const int32_t saved_origin_y=renderer->origin_y;
+		renderer->origin_x+=glide_x;
+		renderer->origin_y+=glide_y;
+		for(int32_t x=vp->clipx[0];x<=vp->clipx[1];++x)
+			{
+			for(int32_t y=vp->clipy[0];y<=vp->clipy[1];++y)
+				redraw_world_tile(renderer,vp,x,y,selected);
+			}
+		for(const render_proxyst &proxy:proxies)
+			{
+			if(static_cast<uint8_t>(proxy.layer)<3)draw_proxy(renderer,proxy);
+			}
+		for(const auto &[x,y]:main_coverage)
+			redraw_above_main(renderer,vp,x,y,selected);
+		for(const render_proxyst &proxy:proxies)
+			{
+			if(static_cast<uint8_t>(proxy.layer)>=3)draw_proxy(renderer,proxy);
+			}
+		for(const auto &[x,y]:upper_coverage)
+			redraw_above_upper(renderer,vp,x,y);
+		renderer->origin_x=saved_origin_x;
+		renderer->origin_y=saved_origin_y;
+		render_set_clip_rect(sdl_renderer,nullptr);
+
+		// Everything was repainted; per-tile coverage bookkeeping restarts after the glide.
+		previous_coverage.clear();
+		return;
+		}
+
 	std::set<std::pair<int32_t,int32_t>> redraw_coverage=current_coverage;
 	redraw_coverage.insert(previous_coverage.begin(),previous_coverage.end());
-	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
 	Uint8 old_r=0,old_g=0,old_b=0,old_a=255;
 	get_render_draw_color(sdl_renderer,&old_r,&old_g,&old_b,&old_a);
 	set_render_draw_color(sdl_renderer,0,0,0,255);
-	const int32_t zoom=renderer->viewport_zoom_factor;
-	const int32_t tile_size=zoom==128?32:std::max(1,zoom*32/128);
 	for(const auto &[x,y]:redraw_coverage)
 		{
 		if(!inside_clip(vp,x,y))continue;
@@ -501,12 +682,15 @@ bool load_sdl(color_ostream &out)
 		LookupPlugin(sdl_handle,"SDL_RenderCopyF"));
 	render_fill_rect=reinterpret_cast<RenderFillRect>(
 		LookupPlugin(sdl_handle,"SDL_RenderFillRect"));
+	render_set_clip_rect=reinterpret_cast<RenderSetClipRect>(
+		LookupPlugin(sdl_handle,"SDL_RenderSetClipRect"));
 	get_render_draw_color=reinterpret_cast<GetRenderDrawColor>(
 		LookupPlugin(sdl_handle,"SDL_GetRenderDrawColor"));
 	set_render_draw_color=reinterpret_cast<SetRenderDrawColor>(
 		LookupPlugin(sdl_handle,"SDL_SetRenderDrawColor"));
 	get_ticks=reinterpret_cast<GetTicks>(LookupPlugin(sdl_handle,"SDL_GetTicks"));
 	if(render_copy_f==nullptr||render_fill_rect==nullptr||
+		render_set_clip_rect==nullptr||
 		get_render_draw_color==nullptr||set_render_draw_color==nullptr||
 		get_ticks==nullptr)
 		{
@@ -529,6 +713,7 @@ void reset_state()
 	previous_pan_x=0;
 	previous_pan_y=0;
 	has_pan_context=false;
+	cancel_camera_glide();
 }
 
 command_result status_command(

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -58,8 +58,14 @@ visual_animation_managerst animation_manager;
 std::set<std::pair<int32_t,int32_t>> previous_coverage;
 uint64_t visual_context_revision=0;
 const void *previous_viewport=nullptr;
-std::array<int32_t,14> previous_view_signature{};
+std::array<int32_t,12> previous_view_signature{};
 bool has_view_signature=false;
+// Map scroll (window_x/window_y) is tracked separately from the reset signature: a pure pan is
+// followed (movements are translated) instead of triggering a full reset, so it must NOT bump the
+// context revision. It only invalidates the viewport-space blackout coverage from the prior frame.
+int32_t previous_pan_x=0;
+int32_t previous_pan_y=0;
+bool has_pan_context=false;
 
 constexpr uint32_t fire_bits=0x70000000U;
 
@@ -67,10 +73,10 @@ void update_visual_context(
 	const df::renderer_2d_base *renderer,
 	const df::graphic_viewportst *vp)
 {
-	const std::array<int32_t,14> signature=
+	// window_x/window_y are deliberately excluded: a horizontal/vertical scroll is followed, not
+	// reset. window_z (z-level) stays, since a z change is not followable.
+	const std::array<int32_t,12> signature=
 		{
-		window_x?*window_x:0,
-		window_y?*window_y:0,
 		window_z?*window_z:0,
 		vp->dim_x,
 		vp->dim_y,
@@ -94,6 +100,16 @@ void update_visual_context(
 	previous_viewport=vp;
 	previous_view_signature=signature;
 	has_view_signature=true;
+
+	// On a pure pan the reset signature is unchanged, but last frame's blackout coverage is in the
+	// old viewport frame, so discard it (the engine repaints the whole scrolled viewport anyway).
+	const int32_t pan_x=window_x?*window_x:0;
+	const int32_t pan_y=window_y?*window_y:0;
+	if(!has_pan_context||previous_pan_x!=pan_x||previous_pan_y!=pan_y)
+		previous_coverage.clear();
+	previous_pan_x=pan_x;
+	previous_pan_y=pan_y;
+	has_pan_context=true;
 }
 
 std::array<int32_t *,6> creature_layers(df::graphic_viewportst *vp)
@@ -130,7 +146,9 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 			vp->screentexpos_upright_creature_old,
 			vp->screentexpos_up_creature_old,
 			vp->screentexpos_upleft_creature_old
-			}
+			},
+		window_x?*window_x:0,
+		window_y?*window_y:0
 		};
 }
 
@@ -508,6 +526,9 @@ void reset_state()
 	previous_viewport=nullptr;
 	previous_view_signature={};
 	has_view_signature=false;
+	previous_pan_x=0;
+	previous_pan_y=0;
+	has_pan_context=false;
 }
 
 command_result status_command(

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -3,6 +3,7 @@
 #include "PluginManager.h"
 #include "VTableInterpose.h"
 
+#include "df/enabler.h"
 #include "df/graphic.h"
 #include "df/graphic_viewportst.h"
 #include "df/renderer_2d_base.h"
@@ -18,6 +19,7 @@
 #include <cmath>
 #include <cstdint>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -27,6 +29,7 @@ using namespace DFHack;
 DFHACK_PLUGIN("smooth-movement");
 DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
+REQUIRE_GLOBAL(enabler);
 REQUIRE_GLOBAL(gps);
 REQUIRE_GLOBAL(window_x);
 REQUIRE_GLOBAL(window_y);
@@ -34,7 +37,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.2.0+smooth-camera";
+constexpr const char *plugin_version="0.2.0+free-camera";
 
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
@@ -70,18 +73,40 @@ int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
 
-// --- smooth camera glide -----------------------------------------------------------------------
-// The camera is visually unbound from the tile grid: when the map scrolls, the view keeps
-// rendering from the OLD position and exponentially catches up to the new one, drawing the world
-// at sub-tile pixel offsets in between. Pure render-state; the real camera (window_x/window_y)
-// is never touched.
+// --- free camera -------------------------------------------------------------------------------
+// The camera is visually unbound from the tile grid. Two layered offsets:
+//   rest      -- a PERSISTENT sub-tile offset in tiles: the free camera. Set by pixel-perfect
+//                middle-mouse drag panning (the view rests wherever released, mid-tile or not)
+//                and by the `smooth-movement camera <fx> <fy>` console command. Survives zoom
+//                and z-level changes. Kept in [-0.5,0.5] by normalization: whole-tile parts are
+//                folded into window_x/window_y (a plain UI scroll write -- NEVER the viewport
+//                dims, which crash DF; the sub-tile strip this leaves at one screen edge has no
+//                buffer data and stays black).
+//   transient -- the decaying scroll glide from before, in pixels, layered on top.
+// Render offset = transient + rest*tile. window_x/window_y remain the game's own tile camera.
 constexpr int32_t camera_max_glide_tiles=3;   // per-jump: farther than this snaps instantly
-constexpr double camera_tau_ms=35.0;          // catch-up time constant (~95% done after 100ms)
-double camera_offset_x=0.0;                   // remaining visual offset, in pixels
-double camera_offset_y=0.0;
+constexpr double camera_tau_ms=35.0;          // transient catch-up (~95% done after 100ms)
+double transient_x=0.0;                       // decaying glide offset, pixels
+double transient_y=0.0;
+double rest_x=0.0;                            // persistent free-camera offset, tiles
+double rest_y=0.0;                            // (positive = view sits WEST/NORTH of window)
 int32_t camera_pending_dx=0;                  // scroll delta announced but not yet in the buffers
 int32_t camera_pending_dy=0;
 int32_t camera_pending_frames=0;
+int32_t self_scroll_x=0;                      // window deltas WE wrote: visual no-ops when landing
+int32_t self_scroll_y=0;
+bool drag_active=false;
+double drag_anchor_vx=0.0;                    // visual camera at drag start, tiles
+double drag_anchor_vy=0.0;
+int32_t drag_anchor_mx=0;                     // precise mouse at drag start, pixels
+int32_t drag_anchor_my=0;
+bool camera_was_offset=false;                 // edge-detects offset->0 for one cleanup redraw
+
+double tile_px(const df::renderer_2d_base *renderer)
+{
+	const int32_t zoom=renderer->viewport_zoom_factor;
+	return double(zoom==128?32:std::max(1,zoom*32/128));
+}
 
 // Did the viewport buffers apply a scroll of (dwx,dwy) this frame? Tested on the BACKGROUND
 // layer: terrain is dense (nonzero nearly everywhere), so this works with no creatures on
@@ -108,22 +133,46 @@ bool background_shift_matches(const df::graphic_viewportst *vp,int32_t dwx,int32
 	return considered>0&&matches*5>=considered*3;
 }
 
-void cancel_camera_glide()
+// Cancel everything except the persistent rest offset (the camera keeps its sub-tile position
+// across zoom/z/resize; only the in-flight animation state is unfollowable).
+void cancel_camera_transients()
 {
-	camera_offset_x=0.0;
-	camera_offset_y=0.0;
+	transient_x=0.0;
+	transient_y=0.0;
 	camera_pending_dx=0;
 	camera_pending_dy=0;
 	camera_pending_frames=0;
+	self_scroll_x=0;
+	self_scroll_y=0;
+	drag_active=false;
 }
 
-// Track scroll changes, start the glide on the frame the buffers apply them, and decay the
-// offset toward zero. Called once per render frame.
+// Fold whole tiles of rest into window_x/window_y so |rest| <= 0.5 (minimal edge strip). The
+// visual position is unchanged: the window write is attributed via self_scroll when it lands.
+void normalize_rest()
+{
+	const int32_t kx=int32_t(-std::llround(rest_x));
+	const int32_t ky=int32_t(-std::llround(rest_y));
+	if(kx!=0&&window_x!=nullptr&&*window_x+kx>=0)
+		{
+		*window_x+=kx;
+		self_scroll_x+=kx;
+		}
+	if(ky!=0&&window_y!=nullptr&&*window_y+ky>=0)
+		{
+		*window_y+=ky;
+		self_scroll_y+=ky;
+		}
+}
+
+// Per-frame camera bookkeeping: observe window scrolls, attribute them when the buffers apply
+// them (glide vs our own normalization writes), drive the drag, decay the transient.
 void update_camera(
 	df::renderer_2d_base *renderer,
 	const df::graphic_viewportst *vp,
 	uint32_t delta_ms)
 {
+	const double tile=tile_px(renderer);
 	const int32_t wx=window_x?*window_x:0;
 	const int32_t wy=window_y?*window_y:0;
 	static int32_t prev_wx=0,prev_wy=0;
@@ -132,8 +181,9 @@ void update_camera(
 		{
 		const int32_t dx=wx-prev_wx;
 		const int32_t dy=wy-prev_wy;
-		if(std::abs(dx)>camera_max_glide_tiles||std::abs(dy)>camera_max_glide_tiles)
-			cancel_camera_glide();   // teleport-like jump: snap
+		if((std::abs(dx)>camera_max_glide_tiles||std::abs(dy)>camera_max_glide_tiles)&&
+			!drag_active)
+			cancel_camera_transients();   // teleport-like jump (recenter/minimap): snap
 		else
 			{
 			camera_pending_dx+=dx;
@@ -149,40 +199,98 @@ void update_camera(
 		{
 		if(std::abs(camera_pending_dx)>camera_max_glide_tiles||
 			std::abs(camera_pending_dy)>camera_max_glide_tiles)
-			cancel_camera_glide();
+			cancel_camera_transients();
 		else if(background_shift_matches(vp,camera_pending_dx,camera_pending_dy))
 			{
-			// The visual jump landed this frame: put the view back where it was and let the
-			// decay glide it to the new position.
-			const int32_t zoom=renderer->viewport_zoom_factor;
-			const double tile=double(zoom==128?32:std::max(1,zoom*32/128));
-			camera_offset_x+=camera_pending_dx*tile;
-			camera_offset_y+=camera_pending_dy*tile;
-			const double cap=tile*(camera_max_glide_tiles+0.5);
-			camera_offset_x=std::clamp(camera_offset_x,-cap,cap);
-			camera_offset_y=std::clamp(camera_offset_y,-cap,cap);
+			// The visual jump landed. Attribute it: the part WE wrote (normalization) is a
+			// visual no-op -- it moves into rest; the remainder is a real scroll and glides
+			// (unless a drag is driving the position directly, which re-derives rest below).
+			rest_x+=self_scroll_x;
+			rest_y+=self_scroll_y;
+			const int32_t game_dx=camera_pending_dx-self_scroll_x;
+			const int32_t game_dy=camera_pending_dy-self_scroll_y;
+			if(!drag_active)
+				{
+				transient_x+=game_dx*tile;
+				transient_y+=game_dy*tile;
+				const double cap=tile*(camera_max_glide_tiles+0.5);
+				transient_x=std::clamp(transient_x,-cap,cap);
+				transient_y=std::clamp(transient_y,-cap,cap);
+				}
+			else
+				{
+				rest_x+=game_dx;   // drag: content moved under a fixed visual; fold fully
+				rest_y+=game_dy;
+				}
 			camera_pending_dx=0;
 			camera_pending_dy=0;
 			camera_pending_frames=0;
+			self_scroll_x=0;
+			self_scroll_y=0;
 			}
 		else if(++camera_pending_frames>4)
 			{
 			camera_pending_dx=0;
 			camera_pending_dy=0;
 			camera_pending_frames=0;
+			self_scroll_x=0;
+			self_scroll_y=0;
 			}
 		}
 
-	if(camera_offset_x!=0.0||camera_offset_y!=0.0)
+	// --- pixel-perfect middle-mouse drag: the view follows the mouse 1:1 and rests where
+	// released. DF's own drag still moves window in tile steps; rest carries the remainder.
+	// Positions are tracked against the CONTENT window (window minus unlanded jumps) so the
+	// buffer lag never causes a visible stutter.
+	const bool mbut=enabler!=nullptr&&enabler->mouse_mbut;
+	const double content_wx=double(wx-camera_pending_dx);
+	const double content_wy=double(wy-camera_pending_dy);
+	if(mbut&&!drag_active&&gps!=nullptr)
+		{
+		drag_active=true;
+		drag_anchor_vx=content_wx-rest_x-transient_x/tile;
+		drag_anchor_vy=content_wy-rest_y-transient_y/tile;
+		drag_anchor_mx=gps->precise_mouse_x;
+		drag_anchor_my=gps->precise_mouse_y;
+		transient_x=0.0;
+		transient_y=0.0;
+		}
+	if(drag_active)
+		{
+		if(!mbut)
+			{
+			drag_active=false;
+			normalize_rest();
+			}
+		else if(gps!=nullptr)
+			{
+			double vx=drag_anchor_vx-double(gps->precise_mouse_x-drag_anchor_mx)/tile;
+			double vy=drag_anchor_vy-double(gps->precise_mouse_y-drag_anchor_my)/tile;
+			rest_x=content_wx-vx;
+			rest_y=content_wy-vy;
+			// If DF's own drag disagrees by more than a tile and a half, rebase on its view.
+			const double lim=1.5;
+			if(rest_x<-lim||rest_x>lim||rest_y<-lim||rest_y>lim)
+				{
+				rest_x=std::clamp(rest_x,-lim,lim);
+				rest_y=std::clamp(rest_y,-lim,lim);
+				drag_anchor_vx=content_wx-rest_x+
+					double(gps->precise_mouse_x-drag_anchor_mx)/tile;
+				drag_anchor_vy=content_wy-rest_y+
+					double(gps->precise_mouse_y-drag_anchor_my)/tile;
+				}
+			}
+		}
+
+	if(transient_x!=0.0||transient_y!=0.0)
 		{
 		const double k=std::exp(-double(delta_ms)/camera_tau_ms);
-		camera_offset_x*=k;
-		camera_offset_y*=k;
-		if(std::abs(camera_offset_x)<0.5&&std::abs(camera_offset_y)<0.5)
+		transient_x*=k;
+		transient_y*=k;
+		if(std::abs(transient_x)<0.5&&std::abs(transient_y)<0.5)
 			{
-			cancel_camera_glide();
-			// One engine-driven full redraw so the last sub-pixel-shifted frame is replaced.
-			if(gps!=nullptr)++gps->force_full_display_count;
+			transient_x=0.0;
+			transient_y=0.0;
 			}
 		}
 }
@@ -216,7 +324,7 @@ void update_visual_context(
 		{
 		++visual_context_revision;
 		previous_coverage.clear();
-		cancel_camera_glide();
+		cancel_camera_transients();
 		}
 	previous_viewport=vp;
 	previous_view_signature=signature;
@@ -537,9 +645,17 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		return;
 	if(render_set_clip_rect!=nullptr)
 		update_camera(renderer,vp,animation_manager.get_frame_delta_ms());
-	const int32_t glide_x=int32_t(std::lround(camera_offset_x));
-	const int32_t glide_y=int32_t(std::lround(camera_offset_y));
+	const double cam_tile=tile_px(renderer);
+	const int32_t glide_x=int32_t(std::lround(transient_x+rest_x*cam_tile));
+	const int32_t glide_y=int32_t(std::lround(transient_y+rest_y*cam_tile));
 	const bool glide=glide_x!=0||glide_y!=0;
+	if(!glide&&camera_was_offset)
+		{
+		// The camera just re-joined the grid: one engine redraw replaces the last shifted frame.
+		camera_was_offset=false;
+		if(gps!=nullptr)++gps->force_full_display_count;
+		}
+	if(glide)camera_was_offset=true;
 	if(!glide&&!animation_manager.requires_full_redraw())
 		return;
 
@@ -713,19 +829,64 @@ void reset_state()
 	previous_pan_x=0;
 	previous_pan_y=0;
 	has_pan_context=false;
-	cancel_camera_glide();
+	cancel_camera_transients();
+	rest_x=0.0;
+	rest_y=0.0;
+	camera_was_offset=false;
 }
 
 command_result status_command(
 	color_ostream &out,
 	std::vector<std::string> &parameters)
 {
-	if(!parameters.empty())return CR_WRONG_USAGE;
-	out.print(
-		"smooth-movement {}: {}\n",
-		plugin_version,
-		is_enabled?"enabled":"disabled");
-	return CR_OK;
+	if(parameters.empty())
+		{
+		out.print(
+			"smooth-movement {}: {}\n",
+			plugin_version,
+			is_enabled?"enabled":"disabled");
+		out.print("camera offset: {:.3f} {:.3f} (tiles east/south of the grid)\n",
+			-rest_x,-rest_y);
+		return CR_OK;
+		}
+	if(parameters[0]=="camera")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("camera offset: {:.3f} {:.3f}\n",-rest_x,-rest_y);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="reset")
+			{
+			rest_x=0.0;
+			rest_y=0.0;
+			return CR_OK;
+			}
+		if(parameters.size()==3)
+			{
+			try
+				{
+				const double fx=std::stod(parameters[1]);
+				const double fy=std::stod(parameters[2]);
+				if(fx<-0.99||fx>0.99||fy<-0.99||fy>0.99)
+					{
+					out.printerr("offsets must be within -0.99..0.99 tiles\n");
+					return CR_FAILURE;
+					}
+				// User-facing: positive = view sits east/south of the grid position.
+				rest_x=-fx;
+				rest_y=-fy;
+				normalize_rest();
+				return CR_OK;
+				}
+			catch(...)
+				{
+				return CR_WRONG_USAGE;
+				}
+			}
+		return CR_WRONG_USAGE;
+		}
+	return CR_WRONG_USAGE;
 }
 
 } // namespace
@@ -735,7 +896,7 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 {
 	commands.emplace_back(
 		"smooth-movement",
-		"Show smooth movement status.",
+		"Smooth movement status / free-camera offset (camera <fx> <fy> | camera reset).",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -37,7 +37,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.2.0+free-camera";
+constexpr const char *plugin_version="0.2.0+free-camera.2";
 
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
@@ -108,11 +108,9 @@ double tile_px(const df::renderer_2d_base *renderer)
 	return double(zoom==128?32:std::max(1,zoom*32/128));
 }
 
-// Did the viewport buffers apply a scroll of (dwx,dwy) this frame? Tested on the BACKGROUND
-// layer: terrain is dense (nonzero nearly everywhere), so this works with no creatures on
-// screen. On a uniform screen the test can fire a frame early, but then a shifted render is
-// pixel-identical to an unshifted one, so the mistiming is invisible by construction.
-bool background_shift_matches(const df::graphic_viewportst *vp,int32_t dwx,int32_t dwy)
+// Match ratio of "buffers shifted by (dwx,dwy)" on the background layer: 0..1, or -1 when there
+// is nothing to compare (empty background).
+double background_match_ratio(const df::graphic_viewportst *vp,int32_t dwx,int32_t dwy)
 {
 	int32_t considered=0;
 	int32_t matches=0;
@@ -130,7 +128,8 @@ bool background_shift_matches(const df::graphic_viewportst *vp,int32_t dwx,int32
 			if(vp->screentexpos_background_old[sx*vp->dim_y+sy]==cur)++matches;
 			}
 		}
-	return considered>0&&matches*5>=considered*3;
+	if(considered==0)return -1.0;
+	return double(matches)/double(considered);
 }
 
 // Cancel everything except the persistent rest offset (the camera keeps its sub-tile position
@@ -162,6 +161,38 @@ void normalize_rest()
 		{
 		*window_y+=ky;
 		self_scroll_y+=ky;
+		}
+}
+
+// A scroll of (ax,ay) tiles has landed in the buffers: our own normalization writes are visual
+// no-ops (they move into rest); the remainder is a real scroll and glides -- unless a drag is
+// driving the position directly, in which case it folds into rest wholesale.
+void attribute_landed(int32_t ax,int32_t ay,double tile)
+{
+	int32_t sx=0;
+	if(self_scroll_x!=0&&(self_scroll_x>0)==(ax>0)&&ax!=0)
+		sx=(std::abs(self_scroll_x)<=std::abs(ax))?self_scroll_x:ax;
+	int32_t sy=0;
+	if(self_scroll_y!=0&&(self_scroll_y>0)==(ay>0)&&ay!=0)
+		sy=(std::abs(self_scroll_y)<=std::abs(ay))?self_scroll_y:ay;
+	self_scroll_x-=sx;
+	self_scroll_y-=sy;
+	rest_x+=sx;
+	rest_y+=sy;
+	const int32_t gx=ax-sx;
+	const int32_t gy=ay-sy;
+	if(drag_active)
+		{
+		rest_x+=gx;
+		rest_y+=gy;
+		}
+	else
+		{
+		transient_x+=gx*tile;
+		transient_y+=gy*tile;
+		const double cap=tile*(camera_max_glide_tiles+0.5);
+		transient_x=std::clamp(transient_x,-cap,cap);
+		transient_y=std::clamp(transient_y,-cap,cap);
 		}
 }
 
@@ -197,44 +228,77 @@ void update_camera(
 
 	if(camera_pending_dx!=0||camera_pending_dy!=0)
 		{
-		if(std::abs(camera_pending_dx)>camera_max_glide_tiles||
-			std::abs(camera_pending_dy)>camera_max_glide_tiles)
-			cancel_camera_transients();
-		else if(background_shift_matches(vp,camera_pending_dx,camera_pending_dy))
+		if(std::abs(camera_pending_dx)>6||std::abs(camera_pending_dy)>6)
 			{
-			// The visual jump landed. Attribute it: the part WE wrote (normalization) is a
-			// visual no-op -- it moves into rest; the remainder is a real scroll and glides
-			// (unless a drag is driving the position directly, which re-derives rest below).
-			rest_x+=self_scroll_x;
-			rest_y+=self_scroll_y;
-			const int32_t game_dx=camera_pending_dx-self_scroll_x;
-			const int32_t game_dy=camera_pending_dy-self_scroll_y;
-			if(!drag_active)
-				{
-				transient_x+=game_dx*tile;
-				transient_y+=game_dy*tile;
-				const double cap=tile*(camera_max_glide_tiles+0.5);
-				transient_x=std::clamp(transient_x,-cap,cap);
-				transient_y=std::clamp(transient_y,-cap,cap);
-				}
-			else
-				{
-				rest_x+=game_dx;   // drag: content moved under a fixed visual; fold fully
-				rest_y+=game_dy;
-				}
+			// Scrolling far outran detection: snap (keep rest, drop the animation debt).
+			transient_x=0.0;
+			transient_y=0.0;
 			camera_pending_dx=0;
 			camera_pending_dy=0;
 			camera_pending_frames=0;
 			self_scroll_x=0;
 			self_scroll_y=0;
 			}
-		else if(++camera_pending_frames>4)
+		else
 			{
-			camera_pending_dx=0;
-			camera_pending_dy=0;
-			camera_pending_frames=0;
-			self_scroll_x=0;
-			self_scroll_y=0;
+			// Fast scrolling applies the pending delta PIECEMEAL: the buffers may hold +1 of a
+			// pending +3 this frame. Testing only the total made landings miss, time out, and
+			// snap -- the fast-scroll jitter. Instead, find the LARGEST applied prefix of the
+			// pending scroll and attribute just that; the rest keeps pending. Ties between
+			// qualifying shifts only happen on uniform terrain, where mistiming is invisible.
+			const int32_t stepx=(camera_pending_dx>0)-(camera_pending_dx<0);
+			const int32_t stepy=(camera_pending_dy>0)-(camera_pending_dy<0);
+			int32_t best_ax=0,best_ay=0,best_mag=-1;
+			double best_score=-1.0;
+			bool no_data=false;
+			for(int32_t ix=0;ix<=std::abs(camera_pending_dx);++ix)
+				{
+				for(int32_t iy=0;iy<=std::abs(camera_pending_dy);++iy)
+					{
+					const double score=background_match_ratio(vp,ix*stepx,iy*stepy);
+					if(score<0.0){no_data=true;break;}
+					const int32_t mag=ix+iy;
+					if(score>=0.6&&(mag>best_mag||(mag==best_mag&&score>best_score)))
+						{
+						best_mag=mag;
+						best_score=score;
+						best_ax=ix*stepx;
+						best_ay=iy*stepy;
+						}
+					}
+				if(no_data)break;
+				}
+			if(no_data)
+				{
+				// Nothing to compare against (empty background): give up on attribution.
+				camera_pending_dx=0;
+				camera_pending_dy=0;
+				camera_pending_frames=0;
+				self_scroll_x=0;
+				self_scroll_y=0;
+				}
+			else if(best_mag>0)
+				{
+				attribute_landed(best_ax,best_ay,tile);
+				camera_pending_dx-=best_ax;
+				camera_pending_dy-=best_ay;
+				camera_pending_frames=0;
+				}
+			else if(best_mag==0)
+				{
+				// Content demonstrably hasn't moved yet: keep waiting, no timeout pressure.
+				camera_pending_frames=0;
+				}
+			else if(++camera_pending_frames>4)
+				{
+				// Neither static nor any prefix recognizable (heavy simultaneous change):
+				// drop the debt without touching the in-flight glide.
+				camera_pending_dx=0;
+				camera_pending_dy=0;
+				camera_pending_frames=0;
+				self_scroll_x=0;
+				self_scroll_y=0;
+				}
 			}
 		}
 

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -113,8 +113,9 @@ int main()
 	assert(!context.get_movement(
 		viewport,viewport_creature_layer::center,1,1).active);
 
-	// A pure camera pan is followable: an in-flight movement is translated by the pan delta so its
-	// sprite tracks the scrolled world instead of floating, and is dropped only once it scrolls off.
+	// Camera-pan handling. window_x/window_y change at input time but the buffers shift on a later
+	// render frame, so the manager must (a) NOT create movements from the buffer shift itself (the
+	// floating-sprite bug), and (b) translate in-flight movements on the frame the shift lands.
 	std::array<int32_t,9> pan_current{};
 	std::array<int32_t,9> pan_previous{};
 	std::array<int32_t,9> pan_empty{};
@@ -130,37 +131,86 @@ int main()
 		0
 		};
 
+	// FLOAT REGRESSION: a stationary creature, pan announced at frame A, buffers shift at frame B.
+	// Frame B's buffers look exactly like a real move ((1,1)->(0,1) with a unique source) — the
+	// manager must recognize it as the pending pan and create NO movement.
+	visual_animation_managerst floaty;
+	pan_previous[1*3+1]=42;
+	pan_current[1*3+1]=42;
+	floaty.begin_frame(4990);
+	floaty.synchronize_viewport(pan_input,true);
+	floaty.end_frame();
+	pan_input.pan_x=1;                   // frame A: window scrolled, buffers unchanged
+	floaty.begin_frame(5000);
+	floaty.synchronize_viewport(pan_input,true);
+	floaty.end_frame();
+	assert(!floaty.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	pan_previous[1*3+1]=42;              // frame B: buffers apply the shift
+	pan_current.fill(0);
+	pan_current[0*3+1]=42;
+	floaty.begin_frame(5010);
+	floaty.synchronize_viewport(pan_input,true);
+	floaty.end_frame();
+	assert(!floaty.get_movement(viewport,viewport_creature_layer::center,0,1).active);
+
+	// FOLLOW: an in-flight movement survives the announce frame untouched and is translated on the
+	// frame the buffers shift, so the sprite tracks the scrolled world.
 	visual_animation_managerst panner;
-	panner.begin_frame(5000);            // baseline: establishes the pan origin
+	pan_current.fill(0);
+	pan_previous.fill(0);
+	pan_input.pan_x=0;
+	panner.begin_frame(5990);
 	panner.synchronize_viewport(pan_input,true);
 	panner.end_frame();
-
 	pan_previous[0*3+1]=42;              // creature steps (0,1) -> (1,1)
 	pan_current[1*3+1]=42;
-	panner.begin_frame(5010);
+	panner.begin_frame(6000);
 	panner.synchronize_viewport(pan_input,true);
 	panner.end_frame();
 	auto moved=panner.get_movement(viewport,viewport_creature_layer::center,1,1);
 	assert(moved.active&&moved.source_x==0&&moved.source_y==1);
 
-	// Pan east by one tile (window_x 0 -> 1) with the SAME context: the creature now sits at
-	// viewport (0,1). The movement must follow — target (1,1)->(0,1), source (0,1)->(-1,1) — not reset.
-	pan_current.fill(0);
+	pan_input.pan_x=1;                   // frame A: pan announced, buffers unchanged
+	pan_previous[0*3+1]=0;
+	pan_previous[1*3+1]=42;              // previous now matches current (stationary at (1,1))
+	panner.begin_frame(6010);
+	panner.synchronize_viewport(pan_input,true);
+	panner.end_frame();
+	moved=panner.get_movement(viewport,viewport_creature_layer::center,1,1);
+	assert(moved.active&&moved.source_x==0);   // untouched: still anchored to the old frame
+
+	pan_current.fill(0);                 // frame B: buffers shift east by one
 	pan_current[0*3+1]=42;
-	pan_input.pan_x=1;
-	panner.begin_frame(5020);
+	panner.begin_frame(6020);
 	panner.synchronize_viewport(pan_input,true);
 	panner.end_frame();
 	assert(!panner.get_movement(viewport,viewport_creature_layer::center,1,1).active);
 	auto followed=panner.get_movement(viewport,viewport_creature_layer::center,0,1);
 	assert(followed.active&&followed.source_x==-1&&followed.source_y==1);
 
-	// Pan far enough that the target scrolls off-screen: the movement is dropped.
-	pan_input.pan_x=4;
-	panner.begin_frame(5030);
-	panner.synchronize_viewport(pan_input,true);
-	panner.end_frame();
-	assert(!panner.get_movement(viewport,viewport_creature_layer::center,0,1).active);
+	// SAME-FRAME: pan announced and buffers shifted in the same call — translated immediately.
+	visual_animation_managerst same_frame;
+	pan_current.fill(0);
+	pan_previous.fill(0);
+	pan_input.pan_x=0;
+	same_frame.begin_frame(6990);
+	same_frame.synchronize_viewport(pan_input,true);
+	same_frame.end_frame();
+	pan_previous[0*3+1]=42;
+	pan_current[1*3+1]=42;
+	same_frame.begin_frame(7000);
+	same_frame.synchronize_viewport(pan_input,true);
+	same_frame.end_frame();
+	assert(same_frame.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	pan_input.pan_x=1;
+	pan_previous=pan_current;
+	pan_current.fill(0);
+	pan_current[0*3+1]=42;
+	same_frame.begin_frame(7010);
+	same_frame.synchronize_viewport(pan_input,true);
+	same_frame.end_frame();
+	followed=same_frame.get_movement(viewport,viewport_creature_layer::center,0,1);
+	assert(followed.active&&followed.source_x==-1);
 
 	// A change that is NOT a pure pan (context revision bump) still resets, even with in-flight work.
 	visual_animation_managerst reset_on_zoom;
@@ -168,17 +218,17 @@ int main()
 	pan_previous.fill(0);
 	pan_input.pan_x=0;
 	pan_input.context_revision=1;
-	reset_on_zoom.begin_frame(6000);
+	reset_on_zoom.begin_frame(8000);
 	reset_on_zoom.synchronize_viewport(pan_input,true);
 	reset_on_zoom.end_frame();
 	pan_previous[0*3+1]=42;
 	pan_current[1*3+1]=42;
-	reset_on_zoom.begin_frame(6010);
+	reset_on_zoom.begin_frame(8010);
 	reset_on_zoom.synchronize_viewport(pan_input,true);
 	reset_on_zoom.end_frame();
 	assert(reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
 	pan_input.context_revision=2;       // e.g. zoom / z-level / resize
-	reset_on_zoom.begin_frame(6020);
+	reset_on_zoom.begin_frame(8020);
 	reset_on_zoom.synchronize_viewport(pan_input,true);
 	reset_on_zoom.end_frame();
 	assert(!reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -112,4 +112,74 @@ int main()
 	context.end_frame();
 	assert(!context.get_movement(
 		viewport,viewport_creature_layer::center,1,1).active);
+
+	// A pure camera pan is followable: an in-flight movement is translated by the pan delta so its
+	// sprite tracks the scrolled world instead of floating, and is dropped only once it scrolls off.
+	std::array<int32_t,9> pan_current{};
+	std::array<int32_t,9> pan_previous{};
+	std::array<int32_t,9> pan_empty{};
+	viewport_visual_animation_inputst pan_input=
+		{
+		viewport,
+		3,
+		3,
+		1,
+		{pan_empty.data(),pan_current.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
+		{pan_empty.data(),pan_previous.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
+		0,
+		0
+		};
+
+	visual_animation_managerst panner;
+	panner.begin_frame(5000);            // baseline: establishes the pan origin
+	panner.synchronize_viewport(pan_input,true);
+	panner.end_frame();
+
+	pan_previous[0*3+1]=42;              // creature steps (0,1) -> (1,1)
+	pan_current[1*3+1]=42;
+	panner.begin_frame(5010);
+	panner.synchronize_viewport(pan_input,true);
+	panner.end_frame();
+	auto moved=panner.get_movement(viewport,viewport_creature_layer::center,1,1);
+	assert(moved.active&&moved.source_x==0&&moved.source_y==1);
+
+	// Pan east by one tile (window_x 0 -> 1) with the SAME context: the creature now sits at
+	// viewport (0,1). The movement must follow — target (1,1)->(0,1), source (0,1)->(-1,1) — not reset.
+	pan_current.fill(0);
+	pan_current[0*3+1]=42;
+	pan_input.pan_x=1;
+	panner.begin_frame(5020);
+	panner.synchronize_viewport(pan_input,true);
+	panner.end_frame();
+	assert(!panner.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	auto followed=panner.get_movement(viewport,viewport_creature_layer::center,0,1);
+	assert(followed.active&&followed.source_x==-1&&followed.source_y==1);
+
+	// Pan far enough that the target scrolls off-screen: the movement is dropped.
+	pan_input.pan_x=4;
+	panner.begin_frame(5030);
+	panner.synchronize_viewport(pan_input,true);
+	panner.end_frame();
+	assert(!panner.get_movement(viewport,viewport_creature_layer::center,0,1).active);
+
+	// A change that is NOT a pure pan (context revision bump) still resets, even with in-flight work.
+	visual_animation_managerst reset_on_zoom;
+	pan_current.fill(0);
+	pan_previous.fill(0);
+	pan_input.pan_x=0;
+	pan_input.context_revision=1;
+	reset_on_zoom.begin_frame(6000);
+	reset_on_zoom.synchronize_viewport(pan_input,true);
+	reset_on_zoom.end_frame();
+	pan_previous[0*3+1]=42;
+	pan_current[1*3+1]=42;
+	reset_on_zoom.begin_frame(6010);
+	reset_on_zoom.synchronize_viewport(pan_input,true);
+	reset_on_zoom.end_frame();
+	assert(reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	pan_input.context_revision=2;       // e.g. zoom / z-level / resize
+	reset_on_zoom.begin_frame(6020);
+	reset_on_zoom.synchronize_viewport(pan_input,true);
+	reset_on_zoom.end_frame();
+	assert(!reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
 }

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -27,9 +27,13 @@ struct viewport_visual_animation_inputst
 	uint64_t context_revision=0;
 	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> current{};
 	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> previous{};
-	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision;
-	// instead in-flight movements are translated by the pan delta so their viewport tiles keep
-	// tracking the scrolled world (otherwise the interpolated sprite floats behind the camera).
+	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision.
+	// The scroll value is only a HINT: it changes at input time, while the viewport buffers shift
+	// on a later render frame. The manager hypothesis-tests the buffers to find the frame the
+	// shift actually lands, translates in-flight movements on that frame (so sprites track the
+	// scrolled world), and suppresses new-movement detection while a pan is pending -- otherwise
+	// the shifted buffers make every panned creature look like a real move and it slides across
+	// the screen (the "floating sprites while jiggling the camera" bug).
 	int32_t pan_x=0;
 	int32_t pan_y=0;
 
@@ -77,6 +81,12 @@ class visual_animation_managerst
 		int32_t pan_x;
 		int32_t pan_y;
 		bool has_pan;
+		// Window-scroll delta not yet observed in the buffers, and how long it has been pending.
+		int32_t pending_dx;
+		int32_t pending_dy;
+		int32_t pending_frames;
+		// Frames left in which new-movement detection stays suppressed after scroll activity.
+		int32_t suppress_frames;
 	};
 
 	uint32_t frame_time_ms;
@@ -93,7 +103,7 @@ class visual_animation_managerst
 			{
 			if(state.viewport==input.viewport)return state;
 			}
-		viewports.push_back({input.viewport,0,0,0,false,false,{},0,0,false});
+		viewports.push_back({input.viewport,0,0,0,false,false,{},0,0,false,0,0,0,0});
 		return viewports.back();
 		}
 
@@ -142,15 +152,21 @@ class visual_animation_managerst
 			const bool context_changed=!state.has_context||
 				state.context_revision!=input.context_revision||
 				state.dim_x!=input.dim_x||state.dim_y!=input.dim_y;
-			// A pure map scroll (pan) is followable: instead of dropping in-flight movements we
-			// shift them by the pan delta so their viewport tiles track the scrolled world, and we
-			// skip NEW detection this frame (a pan makes every stationary sprite look like it moved
-			// by the same delta). Only unfollowable changes (zoom, z-level, resize, viewport swap,
-			// via context_revision/dims) clear movements.
-			const bool pan_changed=state.has_pan&&!context_changed&&
-				(state.pan_x!=input.pan_x||state.pan_y!=input.pan_y);
-			const int32_t pan_dx=input.pan_x-state.pan_x;
-			const int32_t pan_dy=input.pan_y-state.pan_y;
+			// A pure map scroll is followable, but window_x/window_y change at INPUT time while the
+			// viewport buffers shift on a later render frame. So the scroll delta is only accumulated
+			// here as a pending hint; the buffers themselves are hypothesis-tested each frame to find
+			// the frame the shift really lands. On that frame in-flight movements are translated so
+			// they track the scrolled world. While a pan is pending (and briefly after), new-movement
+			// detection is suppressed: a shifted buffer makes every panned creature look like a
+			// "unique same-sprite move between empty cells", which is exactly the bogus 100ms slide
+			// that made sprites float when the camera moved.
+			if(state.has_pan&&(state.pan_x!=input.pan_x||state.pan_y!=input.pan_y))
+				{
+				state.pending_dx+=input.pan_x-state.pan_x;
+				state.pending_dy+=input.pan_y-state.pan_y;
+				state.pending_frames=0;
+				state.suppress_frames=2;
+				}
 			state.context_revision=input.context_revision;
 			state.dim_x=input.dim_x;
 			state.dim_y=input.dim_y;
@@ -161,26 +177,82 @@ class visual_animation_managerst
 			if(context_changed||!allow_new_movements)
 				{
 				state.movements.clear();
+				state.pending_dx=0;
+				state.pending_dy=0;
+				state.pending_frames=0;
+				state.suppress_frames=0;
 				return;
 				}
 
-			if(pan_changed)
+			bool translated=false;
+			if(state.pending_dx!=0||state.pending_dy!=0)
 				{
-				// Re-anchor to the new viewport frame; drop anything scrolled off-screen.
-				state.movements.erase(
-					std::remove_if(
-						state.movements.begin(),
-						state.movements.end(),
-						[&](movementst &movement)
+				// Did the buffers apply the pending scroll? After a scroll of (dwx,dwy) the world
+				// content moves so that current[x] == previous[x+dwx] (same for y). Test that over
+				// the visible creature sprites; a majority match means the shift landed this frame.
+				const int32_t dwx=state.pending_dx;
+				const int32_t dwy=state.pending_dy;
+				int32_t considered=0;
+				int32_t matches=0;
+				for(size_t layer=0;layer<input.current.size();++layer)
+					{
+					const int32_t *current=input.current[layer];
+					const int32_t *previous=input.previous[layer];
+					for(int32_t x=0;x<input.dim_x;++x)
+						{
+						const int32_t sx=x+dwx;
+						if(sx<0||sx>=input.dim_x)continue;
+						for(int32_t y=0;y<input.dim_y;++y)
 							{
-							movement.source_x-=pan_dx;
-							movement.source_y-=pan_dy;
-							movement.target_x-=pan_dx;
-							movement.target_y-=pan_dy;
-							return movement.target_x<0||movement.target_x>=input.dim_x||
-								movement.target_y<0||movement.target_y>=input.dim_y;
-							}),
-					state.movements.end());
+							const int32_t texpos=current[x*input.dim_y+y];
+							if(texpos==0)continue;
+							const int32_t sy=y+dwy;
+							if(sy<0||sy>=input.dim_y)continue;
+							++considered;
+							if(previous[sx*input.dim_y+sy]==texpos)++matches;
+							}
+						}
+					}
+				if(considered==0)
+					{
+					// Nothing visible to anchor the test on: nothing to animate either.
+					state.movements.clear();
+					state.pending_dx=0;
+					state.pending_dy=0;
+					state.pending_frames=0;
+					}
+				else if(matches*2>=considered)
+					{
+					// The shift landed: re-anchor in-flight movements to the new viewport frame and
+					// drop anything scrolled off-screen.
+					state.movements.erase(
+						std::remove_if(
+							state.movements.begin(),
+							state.movements.end(),
+							[&](movementst &movement)
+								{
+								movement.source_x-=dwx;
+								movement.source_y-=dwy;
+								movement.target_x-=dwx;
+								movement.target_y-=dwy;
+								return movement.target_x<0||movement.target_x>=input.dim_x||
+									movement.target_y<0||movement.target_y>=input.dim_y;
+								}),
+						state.movements.end());
+					state.pending_dx=0;
+					state.pending_dy=0;
+					state.pending_frames=0;
+					translated=true;
+					}
+				else if(++state.pending_frames>4)
+					{
+					// The shift never showed up recognizably (heavy simultaneous movement, culled
+					// render, ...): fall back to the safe reset behavior.
+					state.movements.clear();
+					state.pending_dx=0;
+					state.pending_dy=0;
+					state.pending_frames=0;
+					}
 				}
 
 			state.movements.erase(
@@ -196,62 +268,65 @@ class visual_animation_managerst
 						}),
 				state.movements.end());
 
-			if(!pan_changed)
-			{
-			const int32_t tile_count=input.dim_x*input.dim_y;
-			std::vector<uint8_t> claimed_sources(tile_count);
-			for(size_t layer=0;layer<input.current.size();++layer)
+			const bool suppress=translated||
+				state.pending_dx!=0||state.pending_dy!=0||state.suppress_frames>0;
+			if(state.suppress_frames>0)--state.suppress_frames;
+			if(!suppress)
 				{
-				std::fill(claimed_sources.begin(),claimed_sources.end(),0);
-				const int32_t *current=input.current[layer];
-				const int32_t *previous=input.previous[layer];
-				for(int32_t x=0;x<input.dim_x;++x)
+				const int32_t tile_count=input.dim_x*input.dim_y;
+				std::vector<uint8_t> claimed_sources(tile_count);
+				for(size_t layer=0;layer<input.current.size();++layer)
 					{
-					for(int32_t y=0;y<input.dim_y;++y)
+					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
+					const int32_t *current=input.current[layer];
+					const int32_t *previous=input.previous[layer];
+					for(int32_t x=0;x<input.dim_x;++x)
 						{
-						const int32_t target=x*input.dim_y+y;
-						const int32_t texpos=current[target];
-						// Entity ids are unavailable, so only accept a unique
-						// same-sprite move between empty cells in one layer.
-						if(texpos==0||previous[target]!=0)continue;
-
-						int32_t source=-1;
-						int32_t candidate_count=0;
-						for(int32_t dx=-1;dx<=1;++dx)
+						for(int32_t y=0;y<input.dim_y;++y)
 							{
-							for(int32_t dy=-1;dy<=1;++dy)
+							const int32_t target=x*input.dim_y+y;
+							const int32_t texpos=current[target];
+							// Entity ids are unavailable, so only accept a unique
+							// same-sprite move between empty cells in one layer.
+							if(texpos==0||previous[target]!=0)continue;
+
+							int32_t source=-1;
+							int32_t candidate_count=0;
+							for(int32_t dx=-1;dx<=1;++dx)
 								{
-								if(dx==0&&dy==0)continue;
-								const int32_t source_x=x+dx;
-								const int32_t source_y=y+dy;
-								if(source_x<0||source_x>=input.dim_x||
-									source_y<0||source_y>=input.dim_y)continue;
-								const int32_t candidate=source_x*input.dim_y+source_y;
-								if(!claimed_sources[candidate]&&previous[candidate]==texpos&&
-									current[candidate]==0)
+								for(int32_t dy=-1;dy<=1;++dy)
 									{
-									source=candidate;
-									++candidate_count;
+									if(dx==0&&dy==0)continue;
+									const int32_t source_x=x+dx;
+									const int32_t source_y=y+dy;
+									if(source_x<0||source_x>=input.dim_x||
+										source_y<0||source_y>=input.dim_y)continue;
+									const int32_t candidate=source_x*input.dim_y+source_y;
+									if(!claimed_sources[candidate]&&previous[candidate]==texpos&&
+										current[candidate]==0)
+										{
+										source=candidate;
+										++candidate_count;
+										}
 									}
 								}
-							}
-						if(candidate_count!=1)continue;
+							if(candidate_count!=1)continue;
 
-						claimed_sources[source]=1;
-						state.movements.push_back(
-							{
-							static_cast<viewport_creature_layer>(layer),
-							texpos,
-							source/input.dim_y,
-							source%input.dim_y,
-							x,
-							y,
-							frame_time_ms
-							});
+							claimed_sources[source]=1;
+							state.movements.push_back(
+								{
+								static_cast<viewport_creature_layer>(layer),
+								texpos,
+								source/input.dim_y,
+								source%input.dim_y,
+								x,
+								y,
+								frame_time_ms
+								});
+							}
 						}
 					}
 				}
-			}
 			if(!state.movements.empty())force_full_redraw=true;
 			}
 

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -27,6 +27,11 @@ struct viewport_visual_animation_inputst
 	uint64_t context_revision=0;
 	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> current{};
 	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> previous{};
+	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision;
+	// instead in-flight movements are translated by the pan delta so their viewport tiles keep
+	// tracking the scrolled world (otherwise the interpolated sprite floats behind the camera).
+	int32_t pan_x=0;
+	int32_t pan_y=0;
 
 	bool valid() const
 		{
@@ -69,6 +74,9 @@ class visual_animation_managerst
 		bool has_context;
 		bool seen;
 		std::vector<movementst> movements;
+		int32_t pan_x;
+		int32_t pan_y;
+		bool has_pan;
 	};
 
 	uint32_t frame_time_ms;
@@ -85,7 +93,7 @@ class visual_animation_managerst
 			{
 			if(state.viewport==input.viewport)return state;
 			}
-		viewports.push_back({input.viewport,0,0,0,false,false,{}});
+		viewports.push_back({input.viewport,0,0,0,false,false,{},0,0,false});
 		return viewports.back();
 		}
 
@@ -134,14 +142,45 @@ class visual_animation_managerst
 			const bool context_changed=!state.has_context||
 				state.context_revision!=input.context_revision||
 				state.dim_x!=input.dim_x||state.dim_y!=input.dim_y;
+			// A pure map scroll (pan) is followable: instead of dropping in-flight movements we
+			// shift them by the pan delta so their viewport tiles track the scrolled world, and we
+			// skip NEW detection this frame (a pan makes every stationary sprite look like it moved
+			// by the same delta). Only unfollowable changes (zoom, z-level, resize, viewport swap,
+			// via context_revision/dims) clear movements.
+			const bool pan_changed=state.has_pan&&!context_changed&&
+				(state.pan_x!=input.pan_x||state.pan_y!=input.pan_y);
+			const int32_t pan_dx=input.pan_x-state.pan_x;
+			const int32_t pan_dy=input.pan_y-state.pan_y;
 			state.context_revision=input.context_revision;
 			state.dim_x=input.dim_x;
 			state.dim_y=input.dim_y;
 			state.has_context=true;
+			state.pan_x=input.pan_x;
+			state.pan_y=input.pan_y;
+			state.has_pan=true;
 			if(context_changed||!allow_new_movements)
 				{
 				state.movements.clear();
 				return;
+				}
+
+			if(pan_changed)
+				{
+				// Re-anchor to the new viewport frame; drop anything scrolled off-screen.
+				state.movements.erase(
+					std::remove_if(
+						state.movements.begin(),
+						state.movements.end(),
+						[&](movementst &movement)
+							{
+							movement.source_x-=pan_dx;
+							movement.source_y-=pan_dy;
+							movement.target_x-=pan_dx;
+							movement.target_y-=pan_dy;
+							return movement.target_x<0||movement.target_x>=input.dim_x||
+								movement.target_y<0||movement.target_y>=input.dim_y;
+							}),
+					state.movements.end());
 				}
 
 			state.movements.erase(
@@ -157,6 +196,8 @@ class visual_animation_managerst
 						}),
 				state.movements.end());
 
+			if(!pan_changed)
+			{
 			const int32_t tile_count=input.dim_x*input.dim_y;
 			std::vector<uint8_t> claimed_sources(tile_count);
 			for(size_t layer=0;layer<input.current.size();++layer)
@@ -210,6 +251,7 @@ class visual_animation_managerst
 						}
 					}
 				}
+			}
 			if(!state.movements.empty())force_full_redraw=true;
 			}
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/9dfbcdf8-c72a-484d-929c-6b4edba12ab2

## Feature

An **optional free camera**: `smooth-movement camera on` visually unbinds the camera from the tile grid. Render-only — the game's tile camera (`window_x`/`window_y`) is never repositioned by the renderer, only read (whole-tile offset folding writes it the same way ordinary scrolling does).

- **Scroll glide**: map scrolls exponentially catch up (~100 ms) instead of stepping, rendering the world at sub-tile pixel offsets. Jumps >3 tiles (recenter, minimap) snap instantly.
- **Pixel-perfect middle-mouse drag panning**: the view follows the mouse 1:1 (the game's own drag supplies the tile-quantized part; a persistent sub-tile `rest` offset carries the remainder) and stays wherever it is released — including half-way between tiles.
- **Command primitive**: `smooth-movement camera <fx> <fy>` sets a persistent sub-tile offset, `camera reset` clears it, bare `camera` prints state.

**Off by default**: plain `enable smooth-movement` behaves exactly as today (creature interpolation only), and the toggle resets to off when the plugin is re-enabled.

## How it works

- Scroll deltas are held as a pending hint; the frame the viewport buffers apply them is detected on the dense **background layer** (works with no creatures on screen). Fast scrolling applies deltas piecemeal, so detection attributes the **largest applied prefix** each frame — testing only the total made landings miss and time out into visible jitter.
- Landed scrolls are attributed: the plugin's own normalization writes are visual no-ops (folded into `rest`), real scrolls glide, and drag frames re-derive `rest` against the content position so buffer lag never stutters.
- Mid-offset frames repaint the map rect at a scoped `origin_x/y` offset, clipped with `SDL_RenderSetClipRect`; creature proxies draw inside the same shifted frame so they stay glued to terrain. Zoom/Z/resize cancel transients; `rest` survives.

## Limitations

- While the view rests off-grid, a sub-tile strip at one screen edge has no viewport data and renders black (normalization keeps it ≤ half a tile). Growing the viewport (`dim_x+1` overscan) was tested live and **crashes DF** — parallel per-cell arrays outside `graphic_viewportst` are sized to the same dims — so the strip is unavoidable from a plugin.
- Off-grid frames repaint the whole map rect each frame.
- `gps.precise_mouse_x/y` are assumed to be absolute screen pixels for the drag.

## Verification

Built against DFHack 53.15-r2 and exercised live in a fortress (Linux, SDL 2D renderer): drag panning rests mid-tile, scroll glide is smooth including under held-key fast scrolling (the prefix-attribution fix was specifically play-tested against jitter), the black strip stays ≤ half a tile, and plain `enable smooth-movement` leaves the camera untouched.

## Stacking

This branch is based on #1 (the creature pan-follow fix) and includes its commits; the free-camera work is the last three commits. Best merged after #1 — or review those commits alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
