### PR TITLE
Fix/interpolate moving overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Animate creature status icons with their creature instead of letting their
+  flashing texture fragments jump between tiles.
+- Animate item-layer wheelbarrows and the vehicle layer used by minecarts;
+  minecart sprite changes no longer interrupt interpolation, and consecutive
+  steps retarget from the current fractional position instead of snapping back
+  to the previous tile center.
 - Optional free camera (`smooth-movement camera on`, off by default): map scrolls
   glide with an exponential catch-up, middle-mouse drag pans pixel-perfectly and
   can rest between tiles, and `camera <fx> <fy>` sets a persistent sub-tile

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # DF Smooth Movement
 
-Smooth, render-only creature movement for Dwarf Fortress through DFHack.
+Smooth, render-only creature, hauled-item, and vehicle movement for Dwarf Fortress through DFHack.
 
-The plugin interpolates matching creature sprites between adjacent tiles. It
-does not change unit positions, pathfinding, simulation ticks, saves, or
-gameplay state.
+The plugin interpolates matching creature, moving-item, and vehicle sprites
+between adjacent tiles. Creature status icons follow the same interpolation as
+their creature. It does not change unit positions, pathfinding, simulation
+ticks, saves, or gameplay state.
 
 ## Compatibility
 
@@ -76,6 +77,8 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
 ## Behavior
 
 - Movement uses a 100 ms smoothstep interpolation.
+- Creature status icons move with their creature, including while flashing.
+- Item-layer wheelbarrows and vehicle-layer minecarts are interpolated.
 - Camera panning is followed: in-flight interpolations are translated by the
   scroll delta so sprites track the world, and drop once they scroll off-screen.
 - Zoom, Z-level changes, resize, and viewport changes reset interpolation for one

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -433,6 +433,22 @@ std::array<int32_t *,6> creature_layers(df::graphic_viewportst *vp)
 		};
 }
 
+std::array<int32_t *,9> visual_layers(df::graphic_viewportst *vp)
+{
+	auto creature=creature_layers(vp);
+	return {
+		creature[0],
+		creature[1],
+		creature[2],
+		creature[3],
+		creature[4],
+		creature[5],
+		vp->screentexpos_vehicle,
+		vp->screentexpos_item,
+		vp->screentexpos_designation
+		};
+}
+
 viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 {
 	return {
@@ -446,7 +462,10 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 			vp->screentexpos_left_creature,
 			vp->screentexpos_upright_creature,
 			vp->screentexpos_up_creature,
-			vp->screentexpos_upleft_creature
+			vp->screentexpos_upleft_creature,
+			vp->screentexpos_vehicle,
+			vp->screentexpos_item,
+			vp->screentexpos_designation
 			},
 		{
 			vp->screentexpos_right_creature_old,
@@ -454,7 +473,10 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 			vp->screentexpos_left_creature_old,
 			vp->screentexpos_upright_creature_old,
 			vp->screentexpos_up_creature_old,
-			vp->screentexpos_upleft_creature_old
+			vp->screentexpos_upleft_creature_old,
+			vp->screentexpos_vehicle_old,
+			vp->screentexpos_item_old,
+			vp->screentexpos_designation_old
 			},
 		window_x?*window_x:0,
 		window_y?*window_y:0
@@ -475,6 +497,13 @@ bool inside_clip(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 bool has_fire(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 {
 	return vp->screentexpos_spatter_flag[x*vp->dim_y+y]&fire_bits;
+}
+
+bool is_main_creature(viewport_creature_layer layer)
+{
+	return layer==viewport_creature_layer::right||
+		layer==viewport_creature_layer::center||
+		layer==viewport_creature_layer::left;
 }
 
 template<typename T>
@@ -505,8 +534,8 @@ class scoped_zerost
 struct render_proxyst
 {
 	viewport_creature_layer layer;
-	int32_t source_x;
-	int32_t source_y;
+	float source_x;
+	float source_y;
 	int32_t target_x;
 	int32_t target_y;
 	int32_t texpos;
@@ -520,18 +549,27 @@ void redraw_world_tile(
 	df::graphic_viewportst *vp,
 	int32_t x,
 	int32_t y,
-	const std::unordered_map<int32_t,uint8_t> &selected)
+	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
 	const auto found=selected.find(index);
-	const uint8_t mask=found==selected.end()?0:found->second;
+	const uint16_t mask=found==selected.end()?0:found->second;
 	auto layers=creature_layers(vp);
+	scoped_zerost<int32_t> item(
+		vp->screentexpos_item+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::item)));
+	scoped_zerost<int32_t> vehicle(
+		vp->screentexpos_vehicle+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::vehicle)));
 	scoped_zerost<int32_t> right(layers[0]+index,mask&(1U<<0));
 	scoped_zerost<int32_t> center(layers[1]+index,mask&(1U<<1));
 	scoped_zerost<int32_t> left(layers[2]+index,mask&(1U<<2));
 	scoped_zerost<int32_t> upright(layers[3]+index,mask&(1U<<3));
 	scoped_zerost<int32_t> up(layers[4]+index,mask&(1U<<4));
 	scoped_zerost<int32_t> upleft(layers[5]+index,mask&(1U<<5));
+	scoped_zerost<int32_t> designation(
+		vp->screentexpos_designation+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
 
 	for(int32_t lower=7;lower>=0;--lower)
 		{
@@ -542,16 +580,60 @@ void redraw_world_tile(
 	renderer->update_viewport_tile(vp,x,y);
 }
 
+void redraw_above_base(
+	df::renderer_2d_base *renderer,
+	df::graphic_viewportst *vp,
+	int32_t x,
+	int32_t y,
+	viewport_creature_layer layer,
+	const std::unordered_map<int32_t,uint16_t> &selected)
+{
+	const int32_t index=x*vp->dim_y+y;
+	const auto found=selected.find(index);
+	const uint16_t mask=found==selected.end()?0:found->second;
+
+	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
+	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
+	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two+index);
+	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag+index);
+	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag+index);
+	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter+index);
+	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag+index);
+	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag+index);
+	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one+index);
+	scoped_zerost<int32_t> item(vp->screentexpos_item+index);
+	scoped_zerost<int32_t> vehicle(
+		vp->screentexpos_vehicle+index,
+		layer==viewport_creature_layer::vehicle||
+			mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::vehicle)));
+	scoped_zerost<int32_t> right(
+		vp->screentexpos_right_creature+index,mask&(1U<<0));
+	scoped_zerost<int32_t> center(
+		vp->screentexpos+index,mask&(1U<<1));
+	scoped_zerost<int32_t> left(
+		vp->screentexpos_left_creature+index,mask&(1U<<2));
+	scoped_zerost<int32_t> upright(
+		vp->screentexpos_upright_creature+index,mask&(1U<<3));
+	scoped_zerost<int32_t> up(
+		vp->screentexpos_up_creature+index,mask&(1U<<4));
+	scoped_zerost<int32_t> upleft(
+		vp->screentexpos_upleft_creature+index,mask&(1U<<5));
+	scoped_zerost<int32_t> designation(
+		vp->screentexpos_designation+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
+	renderer->update_viewport_tile(vp,x,y);
+}
+
 void redraw_above_main(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
 	int32_t x,
 	int32_t y,
-	const std::unordered_map<int32_t,uint8_t> &selected)
+	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
 	const auto found=selected.find(index);
-	const uint8_t mask=found==selected.end()?0:found->second;
+	const uint16_t mask=found==selected.end()?0:found->second;
 
 	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
 	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
@@ -574,6 +656,9 @@ void redraw_above_main(
 		vp->screentexpos_up_creature+index,mask&(1U<<4));
 	scoped_zerost<int32_t> upleft(
 		vp->screentexpos_upleft_creature+index,mask&(1U<<5));
+	scoped_zerost<int32_t> designation(
+		vp->screentexpos_designation+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
 	renderer->update_viewport_tile(vp,x,y);
 }
 
@@ -581,9 +666,12 @@ void redraw_above_upper(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
 	int32_t x,
-	int32_t y)
+	int32_t y,
+	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
+	const auto found=selected.find(index);
+	const uint16_t mask=found==selected.end()?0:found->second;
 	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
 	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
 	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two+index);
@@ -607,6 +695,9 @@ void redraw_above_upper(
 	scoped_zerost<int32_t> upright(vp->screentexpos_upright_creature+index);
 	scoped_zerost<int32_t> up(vp->screentexpos_up_creature+index);
 	scoped_zerost<int32_t> upleft(vp->screentexpos_upleft_creature+index);
+	scoped_zerost<int32_t> designation(
+		vp->screentexpos_designation+index,
+		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
 	renderer->update_viewport_tile(vp,x,y);
 }
 
@@ -615,9 +706,9 @@ void draw_proxy(df::renderer_2d_base *renderer,const render_proxyst &proxy)
 	const int32_t zoom=renderer->viewport_zoom_factor;
 	const int32_t target_x=tile_pixel(proxy.target_x,renderer->origin_x,zoom);
 	const int32_t target_y=tile_pixel(proxy.target_y,renderer->origin_y,zoom);
-	const int32_t source_x=tile_pixel(proxy.source_x,renderer->origin_x,zoom);
-	const int32_t source_y=tile_pixel(proxy.source_y,renderer->origin_y,zoom);
 	const float tile_size=float(zoom==128?32:std::max(1,zoom*32/128));
+	const float source_x=target_x+(proxy.source_x-proxy.target_x)*tile_size;
+	const float source_y=target_y+(proxy.source_y-proxy.target_y)*tile_size;
 	const SDL_FRect destination=
 		{
 		source_x+(target_x-source_x)*proxy.progress,
@@ -637,19 +728,61 @@ std::vector<render_proxyst> collect_proxies(
 	df::graphic_viewportst *vp)
 {
 	std::vector<render_proxyst> proxies;
-	auto layers=creature_layers(vp);
-	for(int32_t y=0;y<vp->dim_y;++y)
+	auto layers=visual_layers(vp);
+	const std::array order={
+		viewport_creature_layer::center,
+		viewport_creature_layer::item,
+		viewport_creature_layer::vehicle,
+		viewport_creature_layer::right,
+		viewport_creature_layer::left,
+		viewport_creature_layer::upright,
+		viewport_creature_layer::up,
+		viewport_creature_layer::upleft,
+		viewport_creature_layer::designation
+		};
+	for(viewport_creature_layer visual_layer:order)
 		{
-		for(int32_t x=0;x<vp->dim_x;++x)
+		const size_t layer=static_cast<size_t>(visual_layer);
+		for(int32_t y=0;y<vp->dim_y;++y)
 			{
-			const int32_t index=x*vp->dim_y+y;
-			for(size_t layer=0;layer<layers.size();++layer)
+			for(int32_t x=0;x<vp->dim_x;++x)
 				{
+				const int32_t index=x*vp->dim_y+y;
 				const int32_t texpos=layers[layer][index];
 				if(texpos==0)continue;
 				const auto movement=animation_manager.get_movement(
 					vp,static_cast<viewport_creature_layer>(layer),x,y);
 				if(!movement.active)continue;
+				if(layer!=static_cast<size_t>(viewport_creature_layer::center)&&
+					layer!=static_cast<size_t>(viewport_creature_layer::vehicle)&&
+					layer!=static_cast<size_t>(viewport_creature_layer::item))
+					{
+					bool anchored=false;
+					for(const render_proxyst &anchor:proxies)
+						{
+						if(anchor.layer==viewport_creature_layer::center&&
+							std::abs(anchor.target_x-x)<=1&&
+							std::abs(anchor.target_y-y)<=1&&
+							anchor.source_x-anchor.target_x==movement.source_x-x&&
+							anchor.source_y-anchor.target_y==movement.source_y-y&&
+							anchor.progress==movement.progress)anchored=true;
+						}
+					if(!anchored)continue;
+					}
+				if(visual_layer==viewport_creature_layer::item&&movement.inherited)
+					{
+					const int32_t source_x=x-
+						((x>movement.source_x)-(x<movement.source_x));
+					const int32_t source_y=y-
+						((y>movement.source_y)-(y<movement.source_y));
+					if(source_x<0||source_x>=vp->dim_x||
+						source_y<0||source_y>=vp->dim_y)continue;
+					const int32_t source=
+						source_x*vp->dim_y+source_y;
+					if(vp->screentexpos_item_old[source]==0||
+						vp->screentexpos_item_old[index]!=0||
+						layers[layer][source]!=0)continue;
+					}
 
 				render_proxyst proxy=
 					{
@@ -664,18 +797,23 @@ std::vector<render_proxyst> collect_proxies(
 					{}
 					};
 				bool blocked=false;
-				for(int32_t coverage_x=std::min(proxy.source_x,x);
-					coverage_x<=std::max(proxy.source_x,x);++coverage_x)
+				for(int32_t coverage_x=int32_t(std::floor(
+						std::min(proxy.source_x,float(x))));
+					coverage_x<=int32_t(std::ceil(
+						std::max(proxy.source_x,float(x))));++coverage_x)
 					{
-					for(int32_t coverage_y=std::min(proxy.source_y,y);
-						coverage_y<=std::max(proxy.source_y,y);++coverage_y)
+					for(int32_t coverage_y=int32_t(std::floor(
+							std::min(proxy.source_y,float(y))));
+						coverage_y<=int32_t(std::ceil(
+							std::max(proxy.source_y,float(y))));++coverage_y)
 						{
 						if(!inside_clip(vp,coverage_x,coverage_y))
 							{
 							blocked=true;
 							break;
 							}
-						if(layer<3&&has_fire(vp,coverage_x,coverage_y))
+						if(is_main_creature(proxy.layer)&&
+							has_fire(vp,coverage_x,coverage_y))
 							{
 							blocked=true;
 							break;
@@ -741,17 +879,23 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);
 	std::set<std::pair<int32_t,int32_t>> current_coverage;
+	std::set<std::pair<int32_t,int32_t>> item_coverage;
+	std::set<std::pair<int32_t,int32_t>> vehicle_coverage;
 	std::set<std::pair<int32_t,int32_t>> main_coverage;
 	std::set<std::pair<int32_t,int32_t>> upper_coverage;
-	std::unordered_map<int32_t,uint8_t> selected;
+	std::unordered_map<int32_t,uint16_t> selected;
 	for(const render_proxyst &proxy:proxies)
 		{
 		current_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
 		auto &layer_mask=selected[proxy.target_x*vp->dim_y+proxy.target_y];
-		layer_mask|=uint8_t(1U<<static_cast<uint8_t>(proxy.layer));
-		if(static_cast<uint8_t>(proxy.layer)<3)
+		layer_mask|=uint16_t(1U<<static_cast<uint8_t>(proxy.layer));
+		if(proxy.layer==viewport_creature_layer::item)
+			item_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
+		else if(proxy.layer==viewport_creature_layer::vehicle)
+			vehicle_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
+		else if(is_main_creature(proxy.layer))
 			main_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		else
+		else if(proxy.layer!=viewport_creature_layer::designation)
 			upper_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
 		}
 
@@ -793,16 +937,37 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 			}
 		for(const render_proxyst &proxy:proxies)
 			{
-			if(static_cast<uint8_t>(proxy.layer)<3)draw_proxy(renderer,proxy);
+			if(proxy.layer==viewport_creature_layer::item)draw_proxy(renderer,proxy);
+			}
+		for(const auto &[x,y]:item_coverage)
+			redraw_above_base(
+				renderer,vp,x,y,viewport_creature_layer::item,selected);
+		for(const render_proxyst &proxy:proxies)
+			{
+			if(proxy.layer==viewport_creature_layer::vehicle)draw_proxy(renderer,proxy);
+			}
+		for(const auto &[x,y]:vehicle_coverage)
+			redraw_above_base(
+				renderer,vp,x,y,viewport_creature_layer::vehicle,selected);
+		for(const render_proxyst &proxy:proxies)
+			{
+			if(is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
 			}
 		for(const auto &[x,y]:main_coverage)
 			redraw_above_main(renderer,vp,x,y,selected);
 		for(const render_proxyst &proxy:proxies)
 			{
-			if(static_cast<uint8_t>(proxy.layer)>=3)draw_proxy(renderer,proxy);
+			if(proxy.layer!=viewport_creature_layer::item&&
+				proxy.layer!=viewport_creature_layer::vehicle&&
+				proxy.layer!=viewport_creature_layer::designation&&
+				!is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
 			}
 		for(const auto &[x,y]:upper_coverage)
-			redraw_above_upper(renderer,vp,x,y);
+			redraw_above_upper(renderer,vp,x,y,selected);
+		for(const render_proxyst &proxy:proxies)
+			{
+			if(proxy.layer==viewport_creature_layer::designation)draw_proxy(renderer,proxy);
+			}
 		renderer->origin_x=saved_origin_x;
 		renderer->origin_y=saved_origin_y;
 		render_set_clip_rect(sdl_renderer,nullptr);
@@ -837,16 +1002,35 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		}
 	for(const render_proxyst &proxy:proxies)
 		{
-		if(static_cast<uint8_t>(proxy.layer)<3)draw_proxy(renderer,proxy);
+		if(proxy.layer==viewport_creature_layer::item)draw_proxy(renderer,proxy);
+		}
+	for(const auto &[x,y]:item_coverage)
+		redraw_above_base(renderer,vp,x,y,viewport_creature_layer::item,selected);
+	for(const render_proxyst &proxy:proxies)
+		{
+		if(proxy.layer==viewport_creature_layer::vehicle)draw_proxy(renderer,proxy);
+		}
+	for(const auto &[x,y]:vehicle_coverage)
+		redraw_above_base(renderer,vp,x,y,viewport_creature_layer::vehicle,selected);
+	for(const render_proxyst &proxy:proxies)
+		{
+		if(is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
 		}
 	for(const auto &[x,y]:main_coverage)
 		redraw_above_main(renderer,vp,x,y,selected);
 	for(const render_proxyst &proxy:proxies)
 		{
-		if(static_cast<uint8_t>(proxy.layer)>=3)draw_proxy(renderer,proxy);
+		if(proxy.layer!=viewport_creature_layer::item&&
+			proxy.layer!=viewport_creature_layer::vehicle&&
+			proxy.layer!=viewport_creature_layer::designation&&
+			!is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
 		}
 	for(const auto &[x,y]:upper_coverage)
-		redraw_above_upper(renderer,vp,x,y);
+		redraw_above_upper(renderer,vp,x,y,selected);
+	for(const render_proxyst &proxy:proxies)
+		{
+		if(proxy.layer==viewport_creature_layer::designation)draw_proxy(renderer,proxy);
+		}
 
 	previous_coverage=std::move(current_coverage);
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -769,7 +769,9 @@ std::vector<render_proxyst> collect_proxies(
 						}
 					if(!anchored)continue;
 					}
-				if(visual_layer==viewport_creature_layer::item&&movement.inherited)
+				if((visual_layer==viewport_creature_layer::item||
+					visual_layer==viewport_creature_layer::designation)&&
+					movement.inherited)
 					{
 					const int32_t source_x=x-
 						((x>movement.source_x)-(x<movement.source_x));
@@ -779,9 +781,13 @@ std::vector<render_proxyst> collect_proxies(
 						source_y<0||source_y>=vp->dim_y)continue;
 					const int32_t source=
 						source_x*vp->dim_y+source_y;
-					if(vp->screentexpos_item_old[source]==0||
-						vp->screentexpos_item_old[index]!=0||
-						layers[layer][source]!=0)continue;
+					if(!visual_moved_between_tiles(
+						layers[layer],
+						visual_layer==viewport_creature_layer::item?
+							vp->screentexpos_item_old:
+							vp->screentexpos_designation_old,
+						source,
+						index))continue;
 					}
 
 				render_proxyst proxy=

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 #include <array>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -36,8 +39,8 @@ int main()
 		3,
 		3,
 		1,
-		{empty.data(),current.data(),empty.data(),empty.data(),empty.data(),empty.data()},
-		{empty.data(),previous.data(),empty.data(),empty.data(),empty.data(),empty.data()}
+		{empty.data(),current.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data()},
+		{empty.data(),previous.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data()}
 		};
 
 	visual_animation_managerst movement;
@@ -125,8 +128,8 @@ int main()
 		3,
 		3,
 		1,
-		{pan_empty.data(),pan_current.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
-		{pan_empty.data(),pan_previous.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
+		{pan_empty.data(),pan_current.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
+		{pan_empty.data(),pan_previous.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
 		0,
 		0
 		};
@@ -232,4 +235,117 @@ int main()
 	reset_on_zoom.synchronize_viewport(pan_input,true);
 	reset_on_zoom.end_frame();
 	assert(!reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+
+	// Status fragments inherit nearby center motion even while their texture flashes.
+	std::array<int32_t,9> status_current{};
+	std::array<int32_t,9> status_previous{};
+	current.fill(0);
+	previous.fill(0);
+	input.context_revision=1;
+	input.current.fill(empty.data());
+	input.previous.fill(empty.data());
+	input.current[static_cast<size_t>(viewport_creature_layer::center)]=current.data();
+	input.previous[static_cast<size_t>(viewport_creature_layer::center)]=previous.data();
+	input.current[static_cast<size_t>(viewport_creature_layer::item)]=status_current.data();
+	input.previous[static_cast<size_t>(viewport_creature_layer::item)]=status_previous.data();
+	input.current[static_cast<size_t>(viewport_creature_layer::designation)]=status_current.data();
+	input.previous[static_cast<size_t>(viewport_creature_layer::designation)]=status_previous.data();
+	visual_animation_managerst companion;
+	companion.begin_frame(8990);
+	companion.synchronize_viewport(input,true);
+	companion.end_frame();
+	previous[0*3+1]=42;
+	current[1*3+1]=42;
+	status_current[1*3+0]=91;
+	companion.begin_frame(9000);
+	companion.synchronize_viewport(input,true);
+	companion.end_frame();
+	auto status=companion.get_movement(viewport,viewport_creature_layer::designation,1,0);
+	assert(status.active&&status.source_x==0&&status.source_y==0);
+	const auto carried_item=companion.get_movement(
+		viewport,viewport_creature_layer::item,1,0);
+	assert(carried_item.active&&carried_item.inherited);
+	previous=current;
+	status_current[1*3+0]=92;
+	companion.begin_frame(9050);
+	companion.synchronize_viewport(input,true);
+	companion.end_frame();
+	status=companion.get_movement(viewport,viewport_creature_layer::designation,1,0);
+	assert(status.active&&status.progress==0.5f);
+
+	// Divergent nearby creature movements make companion ownership ambiguous, so the overlay snaps.
+	current.fill(0);
+	previous.fill(0);
+	status_current.fill(0);
+	visual_animation_managerst crowd;
+	crowd.begin_frame(9990);
+	crowd.synchronize_viewport(input,true);
+	crowd.end_frame();
+	previous[0*3+0]=41;
+	current[0*3+1]=41;
+	previous[2*3+2]=42;
+	current[2*3+1]=42;
+	status_current[1*3+1]=99;
+	crowd.begin_frame(10000);
+	crowd.synchronize_viewport(input,true);
+	crowd.end_frame();
+	assert(!crowd.get_movement(
+		viewport,viewport_creature_layer::designation,1,1).active);
+
+	// Wheelbarrows use the item layer and the same independent adjacent-movement detection.
+	current.fill(0);
+	previous.fill(0);
+	input.current.fill(empty.data());
+	input.previous.fill(empty.data());
+	input.current[static_cast<size_t>(viewport_creature_layer::item)]=current.data();
+	input.previous[static_cast<size_t>(viewport_creature_layer::item)]=previous.data();
+	visual_animation_managerst item;
+	item.begin_frame(10990);
+	item.synchronize_viewport(input,true);
+	item.end_frame();
+	previous[0*3+1]=77;
+	current[1*3+1]=77;
+	item.begin_frame(11000);
+	item.synchronize_viewport(input,true);
+	item.end_frame();
+	const auto item_move=item.get_movement(
+		viewport,viewport_creature_layer::item,1,1);
+	assert(item_move.active&&item_move.source_x==0&&item_move.source_y==1);
+
+	// Minecart graphics can change texpos while moving; vehicle identity is tile occupancy.
+	current.fill(0);
+	previous.fill(0);
+	input.current.fill(empty.data());
+	input.previous.fill(empty.data());
+	input.current[static_cast<size_t>(viewport_creature_layer::vehicle)]=current.data();
+	input.previous[static_cast<size_t>(viewport_creature_layer::vehicle)]=previous.data();
+	visual_animation_managerst vehicle;
+	vehicle.begin_frame(11990);
+	vehicle.synchronize_viewport(input,true);
+	vehicle.end_frame();
+	previous[0*3+1]=77;
+	current[1*3+1]=78;
+	vehicle.begin_frame(12000);
+	vehicle.synchronize_viewport(input,true);
+	vehicle.end_frame();
+	assert(vehicle.get_movement(
+		viewport,viewport_creature_layer::vehicle,1,1).active);
+	previous=current;
+	current[1*3+1]=79;
+	vehicle.begin_frame(12050);
+	vehicle.synchronize_viewport(input,true);
+	vehicle.end_frame();
+	const auto cart=vehicle.get_movement(
+		viewport,viewport_creature_layer::vehicle,1,1);
+	assert(cart.active&&cart.progress==0.5f);
+	previous=current;
+	current.fill(0);
+	current[2*3+1]=80;
+	vehicle.begin_frame(12060);
+	vehicle.synchronize_viewport(input,true);
+	vehicle.end_frame();
+	const auto chained=vehicle.get_movement(
+		viewport,viewport_creature_layer::vehicle,2,1);
+	assert(chained.active&&chained.source_x>0.0f&&chained.source_x<1.0f&&
+		chained.progress==0.0f);
 }

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -256,7 +256,14 @@ int main()
 	companion.end_frame();
 	previous[0*3+1]=42;
 	current[1*3+1]=42;
+	status_previous[0*3+0]=90;
 	status_current[1*3+0]=91;
+	assert(visual_moved_between_tiles(
+		status_current.data(),status_previous.data(),0*3+0,1*3+0));
+	status_previous[1*3+0]=80;
+	assert(!visual_moved_between_tiles(
+		status_current.data(),status_previous.data(),0*3+0,1*3+0));
+	status_previous[1*3+0]=0;
 	companion.begin_frame(9000);
 	companion.synchronize_viewport(input,true);
 	companion.end_frame();

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 enum class viewport_creature_layer : uint8_t
@@ -16,6 +17,9 @@ enum class viewport_creature_layer : uint8_t
 	upright,
 	up,
 	upleft,
+	vehicle,
+	item,
+	designation,
 	count
 };
 
@@ -51,9 +55,10 @@ struct viewport_visual_animation_inputst
 struct visual_movement_renderst
 {
 	bool active=false;
-	int32_t source_x=0;
-	int32_t source_y=0;
+	float source_x=0.0f;
+	float source_y=0.0f;
 	float progress=1.0f;
+	bool inherited=false;
 };
 
 class visual_animation_managerst
@@ -62,8 +67,8 @@ class visual_animation_managerst
 	{
 		viewport_creature_layer layer;
 		int32_t texpos;
-		int32_t source_x;
-		int32_t source_y;
+		float source_x;
+		float source_y;
 		int32_t target_x;
 		int32_t target_y;
 		uint32_t start_time_ms;
@@ -96,6 +101,23 @@ class visual_animation_managerst
 	std::vector<viewport_animationst> viewports;
 
 	static constexpr uint32_t movement_duration_ms=100;
+
+	static bool independently_moving(viewport_creature_layer layer)
+		{
+		return layer==viewport_creature_layer::center||
+			layer==viewport_creature_layer::vehicle||
+			layer==viewport_creature_layer::item;
+		}
+
+	static bool same_visual(
+		viewport_creature_layer layer,
+		int32_t current,
+		int32_t previous)
+		{
+		return layer==viewport_creature_layer::vehicle?
+			previous!=0:
+			previous==current;
+		}
 
 	viewport_animationst &get_viewport(const viewport_visual_animation_inputst &input)
 		{
@@ -196,6 +218,8 @@ class visual_animation_managerst
 				int32_t matches=0;
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
+					if(!independently_moving(
+						static_cast<viewport_creature_layer>(layer)))continue;
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
 					for(int32_t x=0;x<input.dim_x;++x)
@@ -209,7 +233,10 @@ class visual_animation_managerst
 							const int32_t sy=y+dwy;
 							if(sy<0||sy>=input.dim_y)continue;
 							++considered;
-							if(previous[sx*input.dim_y+sy]==texpos)++matches;
+							if(same_visual(
+								static_cast<viewport_creature_layer>(layer),
+								texpos,
+								previous[sx*input.dim_y+sy]))++matches;
 							}
 						}
 					}
@@ -255,19 +282,6 @@ class visual_animation_managerst
 					}
 				}
 
-			state.movements.erase(
-				std::remove_if(
-					state.movements.begin(),
-					state.movements.end(),
-					[&](const movementst &movement)
-						{
-						const size_t layer=static_cast<size_t>(movement.layer);
-						const int32_t target=movement.target_x*input.dim_y+movement.target_y;
-						return frame_time_ms-movement.start_time_ms>=movement_duration_ms||
-							input.current[layer][target]!=movement.texpos;
-						}),
-				state.movements.end());
-
 			const bool suppress=translated||
 				state.pending_dx!=0||state.pending_dy!=0||state.suppress_frames>0;
 			if(state.suppress_frames>0)--state.suppress_frames;
@@ -277,6 +291,8 @@ class visual_animation_managerst
 				std::vector<uint8_t> claimed_sources(tile_count);
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
+					if(!independently_moving(
+						static_cast<viewport_creature_layer>(layer)))continue;
 					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
@@ -302,8 +318,12 @@ class visual_animation_managerst
 									if(source_x<0||source_x>=input.dim_x||
 										source_y<0||source_y>=input.dim_y)continue;
 									const int32_t candidate=source_x*input.dim_y+source_y;
-									if(!claimed_sources[candidate]&&previous[candidate]==texpos&&
-										current[candidate]==0)
+								if(!claimed_sources[candidate]&&
+									same_visual(
+										static_cast<viewport_creature_layer>(layer),
+										texpos,
+										previous[candidate])&&
+									current[candidate]==0)
 										{
 										source=candidate;
 										++candidate_count;
@@ -313,20 +333,50 @@ class visual_animation_managerst
 							if(candidate_count!=1)continue;
 
 							claimed_sources[source]=1;
+							float visual_source_x=float(source/input.dim_y);
+							float visual_source_y=float(source%input.dim_y);
+							for(const movementst &movement:state.movements)
+								{
+								if(movement.layer!=
+										static_cast<viewport_creature_layer>(layer)||
+									movement.target_x!=visual_source_x||
+									movement.target_y!=visual_source_y)continue;
+								const float progress=
+									movement_progress(movement.start_time_ms);
+								visual_source_x=movement.source_x+
+									(movement.target_x-movement.source_x)*progress;
+								visual_source_y=movement.source_y+
+									(movement.target_y-movement.source_y)*progress;
+								break;
+								}
 							state.movements.push_back(
 								{
 								static_cast<viewport_creature_layer>(layer),
 								texpos,
-								source/input.dim_y,
-								source%input.dim_y,
+								visual_source_x,
+								visual_source_y,
 								x,
 								y,
 								frame_time_ms
 								});
 							}
 						}
+						}
 					}
-				}
+			state.movements.erase(
+				std::remove_if(
+					state.movements.begin(),
+					state.movements.end(),
+					[&](const movementst &movement)
+						{
+						const size_t layer=static_cast<size_t>(movement.layer);
+						const int32_t target=movement.target_x*input.dim_y+movement.target_y;
+						const int32_t current=input.current[layer][target];
+						return frame_time_ms-movement.start_time_ms>=movement_duration_ms||
+							current==0||
+							!same_visual(movement.layer,current,movement.texpos);
+						}),
+				state.movements.end());
 			if(!state.movements.empty())force_full_redraw=true;
 			}
 
@@ -368,6 +418,7 @@ class visual_animation_managerst
 			for(const viewport_animationst &state:viewports)
 				{
 				if(state.viewport!=viewport)continue;
+				const movementst *companion=nullptr;
 				for(const movementst &movement:state.movements)
 					{
 					if(movement.layer==layer&&movement.target_x==target_x&&
@@ -380,7 +431,28 @@ class visual_animation_managerst
 							movement_progress(movement.start_time_ms)
 							};
 						}
+					if(layer==viewport_creature_layer::vehicle||
+						layer==viewport_creature_layer::center||
+						movement.layer!=viewport_creature_layer::center||
+						std::abs(movement.target_x-target_x)>1||
+						std::abs(movement.target_y-target_y)>1)continue;
+					if(companion!=nullptr&&
+						(companion->source_x-companion->target_x!=
+							movement.source_x-movement.target_x||
+						companion->source_y-companion->target_y!=
+							movement.source_y-movement.target_y||
+						companion->start_time_ms!=movement.start_time_ms))
+						return {};
+					companion=&movement;
 					}
+				if(companion!=nullptr)
+					return {
+						true,
+						target_x+companion->source_x-companion->target_x,
+						target_y+companion->source_y-companion->target_y,
+						movement_progress(companion->start_time_ms),
+						true
+						};
 				break;
 				}
 			return {};

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -61,6 +61,15 @@ struct visual_movement_renderst
 	bool inherited=false;
 };
 
+inline bool visual_moved_between_tiles(
+	const int32_t *current,
+	const int32_t *previous,
+	int32_t source,
+	int32_t target)
+{
+	return previous[source]!=0&&previous[target]==0&&current[source]==0;
+}
+
 class visual_animation_managerst
 {
 	struct movementst


### PR DESCRIPTION
- Fixes wheelbarrows and minecarts
- Stop construction designations from moving when creature walked over