### PR TITLE
Refactor rendering and animate chained creature movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Target DFHack `develop` and reuse DFHack's SDL library handle instead of
+  independently opening and closing SDL.
+- Centralize viewport layer metadata, redraw stages, SDL bindings, and pending
+  state cleanup to remove duplicated rendering policy.
 - Animate creature status icons with their creature instead of letting their
   flashing texture fragments jump between tiles.
 - Animate item-layer wheelbarrows and the vehicle layer used by minecarts;

--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@ ticks, saves, or gameplay state.
 
 ## Compatibility
 
-The current prebuilt release supports:
-
-- Dwarf Fortress 53.15
-- DFHack 53.15-r2
-- Linux or Windows x86-64
-- the SDL 2D renderer
-
-DFHack C++ plugins are ABI-specific. Do not install the prebuilt binary on a
-different DFHack or Dwarf Fortress version. Rebuild from source instead.
+Development currently targets the DFHack `develop` branch and the SDL 2D
+renderer. DFHack C++ plugins are ABI-specific, so rebuild the plugin whenever
+the DFHack or Dwarf Fortress version changes.
 
 ## Install
 
@@ -46,7 +40,7 @@ The status command prints the plugin version and whether it is enabled.
 
 ## Build
 
-Check out the matching DFHack source release and clone this repository under
+Check out DFHack's `develop` branch and clone this repository under
 `plugins/external/df-smooth-movement`. Add this line to
 `plugins/external/CMakeLists.txt`:
 

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -414,6 +414,7 @@ using viewport_layer_memberst=int32_t *df::graphic_viewportst::*;
 
 struct visual_layer_bufferst
 {
+	viewport_visual_layer layer;
 	viewport_layer_memberst current;
 	viewport_layer_memberst previous;
 };
@@ -421,26 +422,48 @@ struct visual_layer_bufferst
 constexpr size_t visual_layer_count=static_cast<size_t>(viewport_visual_layer::count);
 constexpr std::array visual_layer_buffers=
 	{
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_right_creature,
+	visual_layer_bufferst{viewport_visual_layer::right,
+		&df::graphic_viewportst::screentexpos_right_creature,
 		&df::graphic_viewportst::screentexpos_right_creature_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos,
+	visual_layer_bufferst{viewport_visual_layer::center,
+		&df::graphic_viewportst::screentexpos,
 		&df::graphic_viewportst::screentexpos_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_left_creature,
+	visual_layer_bufferst{viewport_visual_layer::left,
+		&df::graphic_viewportst::screentexpos_left_creature,
 		&df::graphic_viewportst::screentexpos_left_creature_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_upright_creature,
+	visual_layer_bufferst{viewport_visual_layer::upright,
+		&df::graphic_viewportst::screentexpos_upright_creature,
 		&df::graphic_viewportst::screentexpos_upright_creature_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_up_creature,
+	visual_layer_bufferst{viewport_visual_layer::up,
+		&df::graphic_viewportst::screentexpos_up_creature,
 		&df::graphic_viewportst::screentexpos_up_creature_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_upleft_creature,
+	visual_layer_bufferst{viewport_visual_layer::upleft,
+		&df::graphic_viewportst::screentexpos_upleft_creature,
 		&df::graphic_viewportst::screentexpos_upleft_creature_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_vehicle,
+	visual_layer_bufferst{viewport_visual_layer::vehicle,
+		&df::graphic_viewportst::screentexpos_vehicle,
 		&df::graphic_viewportst::screentexpos_vehicle_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_item,
+	visual_layer_bufferst{viewport_visual_layer::item,
+		&df::graphic_viewportst::screentexpos_item,
 		&df::graphic_viewportst::screentexpos_item_old},
-	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_designation,
+	visual_layer_bufferst{viewport_visual_layer::designation,
+		&df::graphic_viewportst::screentexpos_designation,
 		&df::graphic_viewportst::screentexpos_designation_old}
 	};
-static_assert(visual_layer_buffers.size()==visual_layer_count);
+
+constexpr bool valid_visual_layer_buffers()
+{
+	uint16_t layers=0;
+	for(const auto &buffer:visual_layer_buffers)
+		{
+		const uint16_t layer=uint16_t(1U<<static_cast<uint8_t>(buffer.layer));
+		if(layers&layer)return false;
+		layers|=layer;
+		}
+	return layers==uint16_t((1U<<visual_layer_count)-1);
+}
+
+static_assert(valid_visual_layer_buffers());
 
 template<typename Viewport>
 auto visual_layers(Viewport *vp,bool previous=false)
@@ -448,10 +471,9 @@ auto visual_layers(Viewport *vp,bool previous=false)
 	using layer_pointer=std::conditional_t<
 		std::is_const_v<Viewport>,const int32_t *,int32_t *>;
 	std::array<layer_pointer,visual_layer_count> layers{};
-	for(size_t i=0;i<layers.size();++i)
-		layers[i]=vp->*(previous?
-			visual_layer_buffers[i].previous:
-			visual_layer_buffers[i].current);
+	for(const auto &buffer:visual_layer_buffers)
+		layers[static_cast<size_t>(buffer.layer)]=vp->*(previous?
+			buffer.previous:buffer.current);
 	return layers;
 }
 
@@ -486,48 +508,43 @@ bool has_fire(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 	return vp->screentexpos_spatter_flag[x*vp->dim_y+y]&fire_bits;
 }
 
-enum class visual_render_groupst
+template<typename T>
+class scoped_value_restorest
 {
-	item,
-	vehicle,
-	main,
-	upper,
-	designation
-};
-
-constexpr visual_render_groupst visual_render_group(viewport_visual_layer layer)
-{
-	if(layer==viewport_visual_layer::item)return visual_render_groupst::item;
-	if(layer==viewport_visual_layer::vehicle)return visual_render_groupst::vehicle;
-	if(layer==viewport_visual_layer::designation)
-		return visual_render_groupst::designation;
-	if(layer==viewport_visual_layer::right||
-		layer==viewport_visual_layer::center||
-		layer==viewport_visual_layer::left)return visual_render_groupst::main;
-	return visual_render_groupst::upper;
-}
-
-template<typename T,T default_value=T{}>
-class scoped_zerost
-{
-	T *value_ptr;
-	T saved{};
+	T &value;
+	T saved;
 
 	public:
-		explicit scoped_zerost(T &value):value_ptr(&value)
+		explicit scoped_value_restorest(T &value,T replacement=T{}):
+			value(value),
+			saved(std::exchange(value,std::move(replacement)))
 			{
-			saved=std::move(value);
-			value=default_value;
+			static_assert(std::is_nothrow_move_assignable_v<T>);
 			}
 
-		~scoped_zerost()
+		~scoped_value_restorest() noexcept
 			{
-			*value_ptr=std::move(saved);
+			value=std::move(saved);
 			}
 
-		scoped_zerost(const scoped_zerost &)=delete;
-		scoped_zerost &operator=(const scoped_zerost &)=delete;
+		scoped_value_restorest(const scoped_value_restorest &)=delete;
+		scoped_value_restorest &operator=(const scoped_value_restorest &)=delete;
+		scoped_value_restorest(scoped_value_restorest &&)=delete;
+		scoped_value_restorest &operator=(scoped_value_restorest &&)=delete;
 };
+
+template<typename Callback>
+void with_zeroed_values(const Callback &callback)
+{
+	callback();
+}
+
+template<typename Callback,typename T,typename... Values>
+void with_zeroed_values(const Callback &callback,T &value,Values &...values)
+{
+	scoped_value_restorest<T> zero(value);
+	with_zeroed_values(callback,values...);
+}
 
 struct render_proxyst
 {
@@ -566,7 +583,7 @@ void with_suppressed_visual_layers(
 		callback();
 	else if(mask&(1U<<Layer))
 		{
-		scoped_zerost<int32_t> zero(layers[Layer][index]);
+		scoped_value_restorest<int32_t> zero(layers[Layer][index]);
 		with_suppressed_visual_layers<Layer+1>(layers,index,mask,callback);
 		}
 	else
@@ -579,16 +596,17 @@ void with_base_suppressed(
 	int32_t index,
 	const Callback &callback)
 {
-	scoped_zerost<int32_t> background(vp->screentexpos_background[index]);
-	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag[index]);
-	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two[index]);
-	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag[index]);
-	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag[index]);
-	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter[index]);
-	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag[index]);
-	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag[index]);
-	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one[index]);
-	callback();
+	with_zeroed_values(
+		callback,
+		vp->screentexpos_background[index],
+		vp->screentexpos_floor_flag[index],
+		vp->screentexpos_background_two[index],
+		vp->screentexpos_liquid_flag[index],
+		vp->screentexpos_spatter_flag[index],
+		vp->screentexpos_spatter[index],
+		vp->screentexpos_ramp_flag[index],
+		vp->screentexpos_shadow_flag[index],
+		vp->screentexpos_building_one[index]);
 }
 
 template<typename Callback>
@@ -599,8 +617,7 @@ void with_main_suppressed(
 {
 	with_base_suppressed(vp,index,[&]
 		{
-		scoped_zerost<int32_t> vermin(vp->screentexpos_vermin[index]);
-		callback();
+		with_zeroed_values(callback,vp->screentexpos_vermin[index]);
 		});
 }
 
@@ -612,12 +629,13 @@ void with_upper_suppressed(
 {
 	with_main_suppressed(vp,index,[&]
 		{
-		scoped_zerost<int32_t> building_two(vp->screentexpos_building_two[index]);
-		scoped_zerost<int32_t> projectile(vp->screentexpos_projectile[index]);
-		scoped_zerost<int32_t> high_flow(vp->screentexpos_high_flow[index]);
-		scoped_zerost<int32_t> top_shadow(vp->screentexpos_top_shadow[index]);
-		scoped_zerost<int32_t> signpost(vp->screentexpos_signpost[index]);
-		callback();
+		with_zeroed_values(
+			callback,
+			vp->screentexpos_building_two[index],
+			vp->screentexpos_projectile[index],
+			vp->screentexpos_high_flow[index],
+			vp->screentexpos_top_shadow[index],
+			vp->screentexpos_signpost[index]);
 		});
 }
 
@@ -643,47 +661,37 @@ void redraw_world_tile(
 		visual_layers(vp),index,selected_mask(selected,index),redraw);
 }
 
-enum class redraw_stagest
+constexpr uint16_t visual_layers_through_group(visual_render_groupst group)
 {
-	item,
-	vehicle,
-	main,
-	upper
-};
+	uint16_t mask=0;
+	for(const auto &descriptor:visual_layer_descriptors)
+		if(descriptor.render_group!=visual_render_groupst::designation&&
+			static_cast<uint8_t>(descriptor.render_group)<=static_cast<uint8_t>(group))
+			mask|=visual_layer_bit(descriptor.layer);
+	return mask;
+}
 
 void redraw_above(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
 	int32_t x,
 	int32_t y,
-	redraw_stagest stage,
+	visual_render_groupst group,
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	constexpr uint16_t item_mask=visual_layer_bit(viewport_visual_layer::item);
-	constexpr uint16_t vehicle_mask=
-		item_mask|visual_layer_bit(viewport_visual_layer::vehicle);
-	constexpr uint16_t main_mask=vehicle_mask|
-		visual_layer_bit(viewport_visual_layer::right)|
-		visual_layer_bit(viewport_visual_layer::center)|
-		visual_layer_bit(viewport_visual_layer::left);
-	constexpr uint16_t upper_mask=main_mask|
-		visual_layer_bit(viewport_visual_layer::upright)|
-		visual_layer_bit(viewport_visual_layer::up)|
-		visual_layer_bit(viewport_visual_layer::upleft);
-	const std::array masks={item_mask,vehicle_mask,main_mask,upper_mask};
 	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		with_suppressed_visual_layers(
 			visual_layers(vp),
 			index,
-			selected_mask(selected,index)|masks[static_cast<size_t>(stage)],
+			selected_mask(selected,index)|visual_layers_through_group(group),
 			redraw);
 		};
-	if(stage==redraw_stagest::item||stage==redraw_stagest::vehicle)
+	if(group==visual_render_groupst::item||group==visual_render_groupst::vehicle)
 		with_base_suppressed(vp,index,suppress_visuals);
-	else if(stage==redraw_stagest::main)
+	else if(group==visual_render_groupst::main)
 		with_main_suppressed(vp,index,suppress_visuals);
 	else
 		with_upper_suppressed(vp,index,suppress_visuals);
@@ -717,19 +725,10 @@ std::vector<render_proxyst> collect_proxies(
 {
 	std::vector<render_proxyst> proxies;
 	auto layers=visual_layers(vp);
-	const std::array order={
-		viewport_visual_layer::center,
-		viewport_visual_layer::item,
-		viewport_visual_layer::vehicle,
-		viewport_visual_layer::right,
-		viewport_visual_layer::left,
-		viewport_visual_layer::upright,
-		viewport_visual_layer::up,
-		viewport_visual_layer::upleft,
-		viewport_visual_layer::designation
-		};
-	for(viewport_visual_layer visual_layer:order)
+	auto previous_layers=visual_layers(vp,true);
+	for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
 		{
+		const viewport_visual_layer visual_layer=visual_layer_at_draw_order(draw_order);
 		const size_t layer=static_cast<size_t>(visual_layer);
 		for(int32_t y=0;y<vp->dim_y;++y)
 			{
@@ -770,9 +769,7 @@ std::vector<render_proxyst> collect_proxies(
 					if(!visual_moved_between_tiles(
 						visual_layer,
 						layers[layer],
-						visual_layer==viewport_visual_layer::item?
-							vp->screentexpos_item_old:
-							vp->screentexpos_designation_old,
+						previous_layers[layer],
 						source,
 						index))continue;
 					}
@@ -841,10 +838,7 @@ using tile_coveragest=std::set<std::pair<int32_t,int32_t>>;
 struct render_coveragest
 {
 	tile_coveragest all;
-	tile_coveragest item;
-	tile_coveragest vehicle;
-	tile_coveragest main;
-	tile_coveragest upper;
+	std::array<tile_coveragest,static_cast<size_t>(visual_render_groupst::count)> groups;
 	std::unordered_map<int32_t,uint16_t> selected;
 };
 
@@ -858,26 +852,8 @@ render_coveragest collect_coverage(
 		coverage.all.insert(proxy.coverage.begin(),proxy.coverage.end());
 		coverage.selected[proxy.target_x*dim_y+proxy.target_y]|=
 			visual_layer_bit(proxy.layer);
-		tile_coveragest *layer_coverage=nullptr;
-		switch(visual_render_group(proxy.layer))
-			{
-			case visual_render_groupst::item:
-			layer_coverage=&coverage.item;
-			break;
-			case visual_render_groupst::vehicle:
-			layer_coverage=&coverage.vehicle;
-			break;
-			case visual_render_groupst::main:
-			layer_coverage=&coverage.main;
-			break;
-			case visual_render_groupst::upper:
-			layer_coverage=&coverage.upper;
-			break;
-			case visual_render_groupst::designation:
-			break;
-			}
-		if(layer_coverage!=nullptr)
-			layer_coverage->insert(proxy.coverage.begin(),proxy.coverage.end());
+		auto &group=coverage.groups[static_cast<size_t>(visual_render_group(proxy.layer))];
+		group.insert(proxy.coverage.begin(),proxy.coverage.end());
 		}
 	return coverage;
 }
@@ -888,33 +864,15 @@ void draw_interpolation_stages(
 	const std::vector<render_proxyst> &proxies,
 	const render_coveragest &coverage)
 {
-	const auto draw_matching=[&](const auto &predicate)
+	for(size_t index=0;index<coverage.groups.size();++index)
 		{
+		const auto group=static_cast<visual_render_groupst>(index);
 		for(const render_proxyst &proxy:proxies)
-			if(predicate(proxy.layer))draw_proxy(renderer,proxy);
-		};
-	const auto redraw=[&](const tile_coveragest &tiles,redraw_stagest stage)
-		{
-		for(const auto &[x,y]:tiles)
-			redraw_above(renderer,vp,x,y,stage,coverage.selected);
-		};
-
-	draw_matching([](viewport_visual_layer layer)
-		{return visual_render_group(layer)==visual_render_groupst::item;});
-	redraw(coverage.item,redraw_stagest::item);
-	draw_matching([](viewport_visual_layer layer)
-		{return visual_render_group(layer)==visual_render_groupst::vehicle;});
-	redraw(coverage.vehicle,redraw_stagest::vehicle);
-	draw_matching([](viewport_visual_layer layer)
-		{return visual_render_group(layer)==visual_render_groupst::main;});
-	redraw(coverage.main,redraw_stagest::main);
-	draw_matching([](viewport_visual_layer layer)
-		{
-		return visual_render_group(layer)==visual_render_groupst::upper;
-		});
-	redraw(coverage.upper,redraw_stagest::upper);
-	draw_matching([](viewport_visual_layer layer)
-		{return visual_render_group(layer)==visual_render_groupst::designation;});
+			if(visual_render_group(proxy.layer)==group)draw_proxy(renderer,proxy);
+		if(group==visual_render_groupst::designation)continue;
+		for(const auto &[x,y]:coverage.groups[index])
+			redraw_above(renderer,vp,x,y,group,coverage.selected);
+		}
 }
 
 void render_interpolated_world(df::renderer_2d_base *renderer)

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -41,7 +41,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.3.0";
+constexpr const char *plugin_version="0.3.1";
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
 #else

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -41,9 +41,15 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.2.0";
+constexpr const char *plugin_version="0.3.0";
+#ifdef WIN32
+constexpr const char *sdl_library="SDL2.dll";
+#else
+constexpr const char *sdl_library="libSDL2-2.0.so.0";
+#endif
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
+DFLibrary *sdl_handle=nullptr;
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
 decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
 decltype(&SDL_RenderSetClipRect) render_set_clip_rect=nullptr;
@@ -762,6 +768,7 @@ std::vector<render_proxyst> collect_proxies(
 					const int32_t source=
 						source_x*vp->dim_y+source_y;
 					if(!visual_moved_between_tiles(
+						visual_layer,
 						layers[layer],
 						visual_layer==viewport_visual_layer::item?
 							vp->screentexpos_item_old:
@@ -1036,6 +1043,8 @@ void renderer_hook::interpose_fn_update_all()
 
 void clear_sdl_bindings()
 {
+	if(sdl_handle!=nullptr)ClosePlugin(sdl_handle);
+	sdl_handle=nullptr;
 	render_copy_f=nullptr;
 	render_fill_rect=nullptr;
 	render_set_clip_rect=nullptr;
@@ -1046,14 +1055,14 @@ void clear_sdl_bindings()
 bool load_sdl(color_ostream &out)
 {
 	clear_sdl_bindings();
-	DFLibrary *handle=DFSDL::obtain_library_handle();
-	if(handle==nullptr)
+	sdl_handle=OpenPlugin(sdl_library);
+	if(sdl_handle==nullptr)
 		{
-		out.printerr("smooth-movement: DFHack has no SDL2 library handle\n");
+		out.printerr("smooth-movement: could not load SDL2\n");
 		return false;
 		}
 	#define bind(name,target) \
-		target=reinterpret_cast<decltype(target)>(LookupPlugin(handle,#name)); \
+		target=reinterpret_cast<decltype(target)>(LookupPlugin(sdl_handle,#name)); \
 		if(target==nullptr) { \
 			out.printerr("smooth-movement: SDL2 function unavailable: " #name "\n"); \
 			clear_sdl_bindings(); \

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 
+#include "Core.h"
+#include "MemAccess.h"
 #include "PluginManager.h"
 #include "VTableInterpose.h"
+
+#include "modules/DFSDL.h"
 
 #include "df/enabler.h"
 #include "df/graphic.h"
@@ -12,7 +16,6 @@
 #include "visual_animation.h"
 
 #include <SDL_render.h>
-#include <SDL_timer.h>
 
 #include <algorithm>
 #include <array>
@@ -20,6 +23,7 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -39,26 +43,12 @@ namespace {
 
 constexpr const char *plugin_version="0.2.0";
 
-#ifdef WIN32
-constexpr const char *sdl_library="SDL2.dll";
-#else
-constexpr const char *sdl_library="libSDL2-2.0.so.0";
-#endif
-
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
-DFLibrary *sdl_handle=nullptr;
-using RenderCopyF=int (*)(SDL_Renderer *,SDL_Texture *,const SDL_Rect *,const SDL_FRect *);
-using RenderFillRect=int (*)(SDL_Renderer *,const SDL_Rect *);
-using RenderSetClipRect=int (*)(SDL_Renderer *,const SDL_Rect *);
-using GetRenderDrawColor=int (*)(SDL_Renderer *,Uint8 *,Uint8 *,Uint8 *,Uint8 *);
-using SetRenderDrawColor=int (*)(SDL_Renderer *,Uint8,Uint8,Uint8,Uint8);
-using GetTicks=Uint32 (*)();
-RenderCopyF render_copy_f=nullptr;
-RenderFillRect render_fill_rect=nullptr;
-RenderSetClipRect render_set_clip_rect=nullptr;
-GetRenderDrawColor get_render_draw_color=nullptr;
-SetRenderDrawColor set_render_draw_color=nullptr;
-GetTicks get_ticks=nullptr;
+decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
+decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
+decltype(&SDL_RenderSetClipRect) render_set_clip_rect=nullptr;
+decltype(&SDL_GetRenderDrawColor) get_render_draw_color=nullptr;
+decltype(&SDL_SetRenderDrawColor) set_render_draw_color=nullptr;
 
 visual_animation_managerst animation_manager;
 std::set<std::pair<int32_t,int32_t>> previous_coverage;
@@ -140,15 +130,20 @@ double background_match_ratio(const df::graphic_viewportst *vp,int32_t dwx,int32
 
 // Cancel everything except the persistent rest offset (the camera keeps its sub-tile position
 // across zoom/z/resize; only the in-flight animation state is unfollowable).
-void cancel_camera_transients()
+void clear_camera_pending()
 {
-	transient_x=0.0;
-	transient_y=0.0;
 	camera_pending_dx=0;
 	camera_pending_dy=0;
 	camera_pending_frames=0;
 	self_scroll_x=0;
 	self_scroll_y=0;
+}
+
+void cancel_camera_transients()
+{
+	transient_x=0.0;
+	transient_y=0.0;
+	clear_camera_pending();
 	drag_active=false;
 }
 
@@ -249,11 +244,7 @@ void update_camera(
 			// Scrolling far outran detection: snap (keep rest, drop the animation debt).
 			transient_x=0.0;
 			transient_y=0.0;
-			camera_pending_dx=0;
-			camera_pending_dy=0;
-			camera_pending_frames=0;
-			self_scroll_x=0;
-			self_scroll_y=0;
+			clear_camera_pending();
 			}
 		else
 			{
@@ -287,11 +278,7 @@ void update_camera(
 			if(no_data)
 				{
 				// Nothing to compare against (empty background): give up on attribution.
-				camera_pending_dx=0;
-				camera_pending_dy=0;
-				camera_pending_frames=0;
-				self_scroll_x=0;
-				self_scroll_y=0;
+				clear_camera_pending();
 				}
 			else if(best_mag>0)
 				{
@@ -309,11 +296,7 @@ void update_camera(
 				{
 				// Neither static nor any prefix recognizable (heavy simultaneous change):
 				// drop the debt without touching the in-flight glide.
-				camera_pending_dx=0;
-				camera_pending_dy=0;
-				camera_pending_frames=0;
-				self_scroll_x=0;
-				self_scroll_y=0;
+				clear_camera_pending();
 				}
 			}
 		}
@@ -421,63 +404,61 @@ void update_visual_context(
 	has_pan_context=true;
 }
 
-std::array<int32_t *,6> creature_layers(df::graphic_viewportst *vp)
-{
-	return {
-		vp->screentexpos_right_creature,
-		vp->screentexpos,
-		vp->screentexpos_left_creature,
-		vp->screentexpos_upright_creature,
-		vp->screentexpos_up_creature,
-		vp->screentexpos_upleft_creature
-		};
-}
+using viewport_layer_memberst=int32_t *df::graphic_viewportst::*;
 
-std::array<int32_t *,9> visual_layers(df::graphic_viewportst *vp)
+struct visual_layer_bufferst
 {
-	auto creature=creature_layers(vp);
-	return {
-		creature[0],
-		creature[1],
-		creature[2],
-		creature[3],
-		creature[4],
-		creature[5],
-		vp->screentexpos_vehicle,
-		vp->screentexpos_item,
-		vp->screentexpos_designation
-		};
+	viewport_layer_memberst current;
+	viewport_layer_memberst previous;
+};
+
+constexpr size_t visual_layer_count=static_cast<size_t>(viewport_visual_layer::count);
+constexpr std::array visual_layer_buffers=
+	{
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_right_creature,
+		&df::graphic_viewportst::screentexpos_right_creature_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos,
+		&df::graphic_viewportst::screentexpos_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_left_creature,
+		&df::graphic_viewportst::screentexpos_left_creature_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_upright_creature,
+		&df::graphic_viewportst::screentexpos_upright_creature_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_up_creature,
+		&df::graphic_viewportst::screentexpos_up_creature_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_upleft_creature,
+		&df::graphic_viewportst::screentexpos_upleft_creature_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_vehicle,
+		&df::graphic_viewportst::screentexpos_vehicle_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_item,
+		&df::graphic_viewportst::screentexpos_item_old},
+	visual_layer_bufferst{&df::graphic_viewportst::screentexpos_designation,
+		&df::graphic_viewportst::screentexpos_designation_old}
+	};
+static_assert(visual_layer_buffers.size()==visual_layer_count);
+
+template<typename Viewport>
+auto visual_layers(Viewport *vp,bool previous=false)
+{
+	using layer_pointer=std::conditional_t<
+		std::is_const_v<Viewport>,const int32_t *,int32_t *>;
+	std::array<layer_pointer,visual_layer_count> layers{};
+	for(size_t i=0;i<layers.size();++i)
+		layers[i]=vp->*(previous?
+			visual_layer_buffers[i].previous:
+			visual_layer_buffers[i].current);
+	return layers;
 }
 
 viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 {
+	const df::graphic_viewportst *const_viewport=vp;
 	return {
 		vp,
 		vp->dim_x,
 		vp->dim_y,
 		visual_context_revision,
-		{
-			vp->screentexpos_right_creature,
-			vp->screentexpos,
-			vp->screentexpos_left_creature,
-			vp->screentexpos_upright_creature,
-			vp->screentexpos_up_creature,
-			vp->screentexpos_upleft_creature,
-			vp->screentexpos_vehicle,
-			vp->screentexpos_item,
-			vp->screentexpos_designation
-			},
-		{
-			vp->screentexpos_right_creature_old,
-			vp->screentexpos_old,
-			vp->screentexpos_left_creature_old,
-			vp->screentexpos_upright_creature_old,
-			vp->screentexpos_up_creature_old,
-			vp->screentexpos_upleft_creature_old,
-			vp->screentexpos_vehicle_old,
-			vp->screentexpos_item_old,
-			vp->screentexpos_designation_old
-			},
+		visual_layers(const_viewport),
+		visual_layers(const_viewport,true),
 		window_x?*window_x:0,
 		window_y?*window_y:0
 		};
@@ -499,32 +480,43 @@ bool has_fire(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 	return vp->screentexpos_spatter_flag[x*vp->dim_y+y]&fire_bits;
 }
 
-bool is_main_creature(viewport_creature_layer layer)
+enum class visual_render_groupst
 {
-	return layer==viewport_creature_layer::right||
-		layer==viewport_creature_layer::center||
-		layer==viewport_creature_layer::left;
+	item,
+	vehicle,
+	main,
+	upper,
+	designation
+};
+
+constexpr visual_render_groupst visual_render_group(viewport_visual_layer layer)
+{
+	if(layer==viewport_visual_layer::item)return visual_render_groupst::item;
+	if(layer==viewport_visual_layer::vehicle)return visual_render_groupst::vehicle;
+	if(layer==viewport_visual_layer::designation)
+		return visual_render_groupst::designation;
+	if(layer==viewport_visual_layer::right||
+		layer==viewport_visual_layer::center||
+		layer==viewport_visual_layer::left)return visual_render_groupst::main;
+	return visual_render_groupst::upper;
 }
 
-template<typename T>
+template<typename T,T default_value=T{}>
 class scoped_zerost
 {
 	T *value_ptr;
 	T saved{};
 
 	public:
-		scoped_zerost(T *ptr,bool enabled=true):value_ptr(enabled?ptr:nullptr)
+		explicit scoped_zerost(T &value):value_ptr(&value)
 			{
-			if(value_ptr!=nullptr)
-				{
-				saved=*value_ptr;
-				*value_ptr=0;
-				}
+			saved=std::move(value);
+			value=default_value;
 			}
 
 		~scoped_zerost()
 			{
-			if(value_ptr!=nullptr)*value_ptr=saved;
+			*value_ptr=std::move(saved);
 			}
 
 		scoped_zerost(const scoped_zerost &)=delete;
@@ -533,7 +525,7 @@ class scoped_zerost
 
 struct render_proxyst
 {
-	viewport_creature_layer layer;
+	viewport_visual_layer layer;
 	float source_x;
 	float source_y;
 	int32_t target_x;
@@ -544,6 +536,85 @@ struct render_proxyst
 	std::set<std::pair<int32_t,int32_t>> coverage;
 };
 
+constexpr uint16_t visual_layer_bit(viewport_visual_layer layer)
+{
+	return uint16_t(1U<<static_cast<uint8_t>(layer));
+}
+
+uint16_t selected_mask(
+	const std::unordered_map<int32_t,uint16_t> &selected,
+	int32_t index)
+{
+	const auto found=selected.find(index);
+	return found==selected.end()?0:found->second;
+}
+
+template<size_t Layer=0,typename Callback>
+void with_suppressed_visual_layers(
+	const std::array<int32_t *,visual_layer_count> &layers,
+	int32_t index,
+	uint16_t mask,
+	const Callback &callback)
+{
+	if constexpr(Layer==visual_layer_count)
+		callback();
+	else if(mask&(1U<<Layer))
+		{
+		scoped_zerost<int32_t> zero(layers[Layer][index]);
+		with_suppressed_visual_layers<Layer+1>(layers,index,mask,callback);
+		}
+	else
+		with_suppressed_visual_layers<Layer+1>(layers,index,mask,callback);
+}
+
+template<typename Callback>
+void with_base_suppressed(
+	df::graphic_viewportst *vp,
+	int32_t index,
+	const Callback &callback)
+{
+	scoped_zerost<int32_t> background(vp->screentexpos_background[index]);
+	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag[index]);
+	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two[index]);
+	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag[index]);
+	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag[index]);
+	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter[index]);
+	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag[index]);
+	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag[index]);
+	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one[index]);
+	callback();
+}
+
+template<typename Callback>
+void with_main_suppressed(
+	df::graphic_viewportst *vp,
+	int32_t index,
+	const Callback &callback)
+{
+	with_base_suppressed(vp,index,[&]
+		{
+		scoped_zerost<int32_t> vermin(vp->screentexpos_vermin[index]);
+		callback();
+		});
+}
+
+template<typename Callback>
+void with_upper_suppressed(
+	df::graphic_viewportst *vp,
+	int32_t index,
+	const Callback &callback)
+{
+	with_main_suppressed(vp,index,[&]
+		{
+		scoped_zerost<int32_t> building_two(vp->screentexpos_building_two[index]);
+		scoped_zerost<int32_t> projectile(vp->screentexpos_projectile[index]);
+		scoped_zerost<int32_t> high_flow(vp->screentexpos_high_flow[index]);
+		scoped_zerost<int32_t> top_shadow(vp->screentexpos_top_shadow[index]);
+		scoped_zerost<int32_t> signpost(vp->screentexpos_signpost[index]);
+		callback();
+		});
+}
+
 void redraw_world_tile(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
@@ -552,153 +623,64 @@ void redraw_world_tile(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto found=selected.find(index);
-	const uint16_t mask=found==selected.end()?0:found->second;
-	auto layers=creature_layers(vp);
-	scoped_zerost<int32_t> item(
-		vp->screentexpos_item+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::item)));
-	scoped_zerost<int32_t> vehicle(
-		vp->screentexpos_vehicle+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::vehicle)));
-	scoped_zerost<int32_t> right(layers[0]+index,mask&(1U<<0));
-	scoped_zerost<int32_t> center(layers[1]+index,mask&(1U<<1));
-	scoped_zerost<int32_t> left(layers[2]+index,mask&(1U<<2));
-	scoped_zerost<int32_t> upright(layers[3]+index,mask&(1U<<3));
-	scoped_zerost<int32_t> up(layers[4]+index,mask&(1U<<4));
-	scoped_zerost<int32_t> upleft(layers[5]+index,mask&(1U<<5));
-	scoped_zerost<int32_t> designation(
-		vp->screentexpos_designation+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
-
-	for(int32_t lower=7;lower>=0;--lower)
+	const auto redraw=[&]
 		{
-		df::graphic_viewportst *lower_vp=gps->lower_viewport[lower];
-		if(lower_vp!=nullptr&&lower_vp->flag.bits.active)
-			renderer->update_viewport_tile(lower_vp,x,y);
-		}
-	renderer->update_viewport_tile(vp,x,y);
+		for(int32_t lower=7;lower>=0;--lower)
+			{
+			df::graphic_viewportst *lower_vp=gps->lower_viewport[lower];
+			if(lower_vp!=nullptr&&lower_vp->flag.bits.active)
+				renderer->update_viewport_tile(lower_vp,x,y);
+			}
+		renderer->update_viewport_tile(vp,x,y);
+		};
+	with_suppressed_visual_layers(
+		visual_layers(vp),index,selected_mask(selected,index),redraw);
 }
 
-void redraw_above_base(
+enum class redraw_stagest
+{
+	item,
+	vehicle,
+	main,
+	upper
+};
+
+void redraw_above(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
 	int32_t x,
 	int32_t y,
-	viewport_creature_layer layer,
+	redraw_stagest stage,
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto found=selected.find(index);
-	const uint16_t mask=found==selected.end()?0:found->second;
-
-	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
-	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
-	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two+index);
-	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag+index);
-	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag+index);
-	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter+index);
-	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag+index);
-	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag+index);
-	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one+index);
-	scoped_zerost<int32_t> item(vp->screentexpos_item+index);
-	scoped_zerost<int32_t> vehicle(
-		vp->screentexpos_vehicle+index,
-		layer==viewport_creature_layer::vehicle||
-			mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::vehicle)));
-	scoped_zerost<int32_t> right(
-		vp->screentexpos_right_creature+index,mask&(1U<<0));
-	scoped_zerost<int32_t> center(
-		vp->screentexpos+index,mask&(1U<<1));
-	scoped_zerost<int32_t> left(
-		vp->screentexpos_left_creature+index,mask&(1U<<2));
-	scoped_zerost<int32_t> upright(
-		vp->screentexpos_upright_creature+index,mask&(1U<<3));
-	scoped_zerost<int32_t> up(
-		vp->screentexpos_up_creature+index,mask&(1U<<4));
-	scoped_zerost<int32_t> upleft(
-		vp->screentexpos_upleft_creature+index,mask&(1U<<5));
-	scoped_zerost<int32_t> designation(
-		vp->screentexpos_designation+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
-	renderer->update_viewport_tile(vp,x,y);
-}
-
-void redraw_above_main(
-	df::renderer_2d_base *renderer,
-	df::graphic_viewportst *vp,
-	int32_t x,
-	int32_t y,
-	const std::unordered_map<int32_t,uint16_t> &selected)
-{
-	const int32_t index=x*vp->dim_y+y;
-	const auto found=selected.find(index);
-	const uint16_t mask=found==selected.end()?0:found->second;
-
-	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
-	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
-	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two+index);
-	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag+index);
-	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag+index);
-	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter+index);
-	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag+index);
-	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag+index);
-	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one+index);
-	scoped_zerost<int32_t> item(vp->screentexpos_item+index);
-	scoped_zerost<int32_t> vehicle(vp->screentexpos_vehicle+index);
-	scoped_zerost<int32_t> vermin(vp->screentexpos_vermin+index);
-	scoped_zerost<int32_t> right(vp->screentexpos_right_creature+index);
-	scoped_zerost<int32_t> center(vp->screentexpos+index);
-	scoped_zerost<int32_t> left(vp->screentexpos_left_creature+index);
-	scoped_zerost<int32_t> upright(
-		vp->screentexpos_upright_creature+index,mask&(1U<<3));
-	scoped_zerost<int32_t> up(
-		vp->screentexpos_up_creature+index,mask&(1U<<4));
-	scoped_zerost<int32_t> upleft(
-		vp->screentexpos_upleft_creature+index,mask&(1U<<5));
-	scoped_zerost<int32_t> designation(
-		vp->screentexpos_designation+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
-	renderer->update_viewport_tile(vp,x,y);
-}
-
-void redraw_above_upper(
-	df::renderer_2d_base *renderer,
-	df::graphic_viewportst *vp,
-	int32_t x,
-	int32_t y,
-	const std::unordered_map<int32_t,uint16_t> &selected)
-{
-	const int32_t index=x*vp->dim_y+y;
-	const auto found=selected.find(index);
-	const uint16_t mask=found==selected.end()?0:found->second;
-	scoped_zerost<int32_t> background(vp->screentexpos_background+index);
-	scoped_zerost<uint64_t> floor_flag(vp->screentexpos_floor_flag+index);
-	scoped_zerost<int32_t> background_two(vp->screentexpos_background_two+index);
-	scoped_zerost<uint32_t> liquid_flag(vp->screentexpos_liquid_flag+index);
-	scoped_zerost<uint32_t> spatter_flag(vp->screentexpos_spatter_flag+index);
-	scoped_zerost<int32_t> spatter(vp->screentexpos_spatter+index);
-	scoped_zerost<uint64_t> ramp_flag(vp->screentexpos_ramp_flag+index);
-	scoped_zerost<uint32_t> shadow_flag(vp->screentexpos_shadow_flag+index);
-	scoped_zerost<int32_t> building_one(vp->screentexpos_building_one+index);
-	scoped_zerost<int32_t> item(vp->screentexpos_item+index);
-	scoped_zerost<int32_t> vehicle(vp->screentexpos_vehicle+index);
-	scoped_zerost<int32_t> vermin(vp->screentexpos_vermin+index);
-	scoped_zerost<int32_t> right(vp->screentexpos_right_creature+index);
-	scoped_zerost<int32_t> center(vp->screentexpos+index);
-	scoped_zerost<int32_t> left(vp->screentexpos_left_creature+index);
-	scoped_zerost<int32_t> building_two(vp->screentexpos_building_two+index);
-	scoped_zerost<int32_t> projectile(vp->screentexpos_projectile+index);
-	scoped_zerost<int32_t> high_flow(vp->screentexpos_high_flow+index);
-	scoped_zerost<int32_t> top_shadow(vp->screentexpos_top_shadow+index);
-	scoped_zerost<int32_t> signpost(vp->screentexpos_signpost+index);
-	scoped_zerost<int32_t> upright(vp->screentexpos_upright_creature+index);
-	scoped_zerost<int32_t> up(vp->screentexpos_up_creature+index);
-	scoped_zerost<int32_t> upleft(vp->screentexpos_upleft_creature+index);
-	scoped_zerost<int32_t> designation(
-		vp->screentexpos_designation+index,
-		mask&(1U<<static_cast<uint8_t>(viewport_creature_layer::designation)));
-	renderer->update_viewport_tile(vp,x,y);
+	constexpr uint16_t item_mask=visual_layer_bit(viewport_visual_layer::item);
+	constexpr uint16_t vehicle_mask=
+		item_mask|visual_layer_bit(viewport_visual_layer::vehicle);
+	constexpr uint16_t main_mask=vehicle_mask|
+		visual_layer_bit(viewport_visual_layer::right)|
+		visual_layer_bit(viewport_visual_layer::center)|
+		visual_layer_bit(viewport_visual_layer::left);
+	constexpr uint16_t upper_mask=main_mask|
+		visual_layer_bit(viewport_visual_layer::upright)|
+		visual_layer_bit(viewport_visual_layer::up)|
+		visual_layer_bit(viewport_visual_layer::upleft);
+	const std::array masks={item_mask,vehicle_mask,main_mask,upper_mask};
+	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto suppress_visuals=[&]
+		{
+		with_suppressed_visual_layers(
+			visual_layers(vp),
+			index,
+			selected_mask(selected,index)|masks[static_cast<size_t>(stage)],
+			redraw);
+		};
+	if(stage==redraw_stagest::item||stage==redraw_stagest::vehicle)
+		with_base_suppressed(vp,index,suppress_visuals);
+	else if(stage==redraw_stagest::main)
+		with_main_suppressed(vp,index,suppress_visuals);
+	else
+		with_upper_suppressed(vp,index,suppress_visuals);
 }
 
 void draw_proxy(df::renderer_2d_base *renderer,const render_proxyst &proxy)
@@ -730,17 +712,17 @@ std::vector<render_proxyst> collect_proxies(
 	std::vector<render_proxyst> proxies;
 	auto layers=visual_layers(vp);
 	const std::array order={
-		viewport_creature_layer::center,
-		viewport_creature_layer::item,
-		viewport_creature_layer::vehicle,
-		viewport_creature_layer::right,
-		viewport_creature_layer::left,
-		viewport_creature_layer::upright,
-		viewport_creature_layer::up,
-		viewport_creature_layer::upleft,
-		viewport_creature_layer::designation
+		viewport_visual_layer::center,
+		viewport_visual_layer::item,
+		viewport_visual_layer::vehicle,
+		viewport_visual_layer::right,
+		viewport_visual_layer::left,
+		viewport_visual_layer::upright,
+		viewport_visual_layer::up,
+		viewport_visual_layer::upleft,
+		viewport_visual_layer::designation
 		};
-	for(viewport_creature_layer visual_layer:order)
+	for(viewport_visual_layer visual_layer:order)
 		{
 		const size_t layer=static_cast<size_t>(visual_layer);
 		for(int32_t y=0;y<vp->dim_y;++y)
@@ -751,16 +733,14 @@ std::vector<render_proxyst> collect_proxies(
 				const int32_t texpos=layers[layer][index];
 				if(texpos==0)continue;
 				const auto movement=animation_manager.get_movement(
-					vp,static_cast<viewport_creature_layer>(layer),x,y);
+					vp,static_cast<viewport_visual_layer>(layer),x,y);
 				if(!movement.active)continue;
-				if(layer!=static_cast<size_t>(viewport_creature_layer::center)&&
-					layer!=static_cast<size_t>(viewport_creature_layer::vehicle)&&
-					layer!=static_cast<size_t>(viewport_creature_layer::item))
+				if(!visual_layer_moves_independently(visual_layer))
 					{
 					bool anchored=false;
 					for(const render_proxyst &anchor:proxies)
 						{
-						if(anchor.layer==viewport_creature_layer::center&&
+						if(anchor.layer==viewport_visual_layer::center&&
 							std::abs(anchor.target_x-x)<=1&&
 							std::abs(anchor.target_y-y)<=1&&
 							anchor.source_x-anchor.target_x==movement.source_x-x&&
@@ -769,8 +749,8 @@ std::vector<render_proxyst> collect_proxies(
 						}
 					if(!anchored)continue;
 					}
-				if((visual_layer==viewport_creature_layer::item||
-					visual_layer==viewport_creature_layer::designation)&&
+				if((visual_layer==viewport_visual_layer::item||
+					visual_layer==viewport_visual_layer::designation)&&
 					movement.inherited)
 					{
 					const int32_t source_x=x-
@@ -783,7 +763,7 @@ std::vector<render_proxyst> collect_proxies(
 						source_x*vp->dim_y+source_y;
 					if(!visual_moved_between_tiles(
 						layers[layer],
-						visual_layer==viewport_creature_layer::item?
+						visual_layer==viewport_visual_layer::item?
 							vp->screentexpos_item_old:
 							vp->screentexpos_designation_old,
 						source,
@@ -792,7 +772,7 @@ std::vector<render_proxyst> collect_proxies(
 
 				render_proxyst proxy=
 					{
-					static_cast<viewport_creature_layer>(layer),
+					static_cast<viewport_visual_layer>(layer),
 					movement.source_x,
 					movement.source_y,
 					x,
@@ -818,7 +798,7 @@ std::vector<render_proxyst> collect_proxies(
 							blocked=true;
 							break;
 							}
-						if(is_main_creature(proxy.layer)&&
+						if(visual_render_group(proxy.layer)==visual_render_groupst::main&&
 							has_fire(vp,coverage_x,coverage_y))
 							{
 							blocked=true;
@@ -849,12 +829,93 @@ std::vector<render_proxyst> collect_proxies(
 	return proxies;
 }
 
+using tile_coveragest=std::set<std::pair<int32_t,int32_t>>;
+
+struct render_coveragest
+{
+	tile_coveragest all;
+	tile_coveragest item;
+	tile_coveragest vehicle;
+	tile_coveragest main;
+	tile_coveragest upper;
+	std::unordered_map<int32_t,uint16_t> selected;
+};
+
+render_coveragest collect_coverage(
+	const std::vector<render_proxyst> &proxies,
+	int32_t dim_y)
+{
+	render_coveragest coverage;
+	for(const render_proxyst &proxy:proxies)
+		{
+		coverage.all.insert(proxy.coverage.begin(),proxy.coverage.end());
+		coverage.selected[proxy.target_x*dim_y+proxy.target_y]|=
+			visual_layer_bit(proxy.layer);
+		tile_coveragest *layer_coverage=nullptr;
+		switch(visual_render_group(proxy.layer))
+			{
+			case visual_render_groupst::item:
+			layer_coverage=&coverage.item;
+			break;
+			case visual_render_groupst::vehicle:
+			layer_coverage=&coverage.vehicle;
+			break;
+			case visual_render_groupst::main:
+			layer_coverage=&coverage.main;
+			break;
+			case visual_render_groupst::upper:
+			layer_coverage=&coverage.upper;
+			break;
+			case visual_render_groupst::designation:
+			break;
+			}
+		if(layer_coverage!=nullptr)
+			layer_coverage->insert(proxy.coverage.begin(),proxy.coverage.end());
+		}
+	return coverage;
+}
+
+void draw_interpolation_stages(
+	df::renderer_2d_base *renderer,
+	df::graphic_viewportst *vp,
+	const std::vector<render_proxyst> &proxies,
+	const render_coveragest &coverage)
+{
+	const auto draw_matching=[&](const auto &predicate)
+		{
+		for(const render_proxyst &proxy:proxies)
+			if(predicate(proxy.layer))draw_proxy(renderer,proxy);
+		};
+	const auto redraw=[&](const tile_coveragest &tiles,redraw_stagest stage)
+		{
+		for(const auto &[x,y]:tiles)
+			redraw_above(renderer,vp,x,y,stage,coverage.selected);
+		};
+
+	draw_matching([](viewport_visual_layer layer)
+		{return visual_render_group(layer)==visual_render_groupst::item;});
+	redraw(coverage.item,redraw_stagest::item);
+	draw_matching([](viewport_visual_layer layer)
+		{return visual_render_group(layer)==visual_render_groupst::vehicle;});
+	redraw(coverage.vehicle,redraw_stagest::vehicle);
+	draw_matching([](viewport_visual_layer layer)
+		{return visual_render_group(layer)==visual_render_groupst::main;});
+	redraw(coverage.main,redraw_stagest::main);
+	draw_matching([](viewport_visual_layer layer)
+		{
+		return visual_render_group(layer)==visual_render_groupst::upper;
+		});
+	redraw(coverage.upper,redraw_stagest::upper);
+	draw_matching([](viewport_visual_layer layer)
+		{return visual_render_group(layer)==visual_render_groupst::designation;});
+}
+
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 
 	if(vp!=nullptr)update_visual_context(renderer,vp);
-	animation_manager.begin_frame(get_ticks());
+	animation_manager.begin_frame(Core::getInstance().p->getTickCount());
 	if(vp!=nullptr)
 		{
 		const auto input=animation_input(vp);
@@ -864,11 +925,9 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		}
 	animation_manager.end_frame();
 
-	if(vp==nullptr||!vp->flag.bits.active||
-		render_copy_f==nullptr||renderer->sdl_renderer==nullptr)
+	if(vp==nullptr||!vp->flag.bits.active||renderer->sdl_renderer==nullptr)
 		return;
-	if(render_set_clip_rect!=nullptr)
-		update_camera(renderer,vp,animation_manager.get_frame_delta_ms());
+	update_camera(renderer,vp,animation_manager.get_frame_delta_ms());
 	const double cam_tile=tile_px(renderer);
 	const int32_t glide_x=int32_t(std::lround(transient_x+rest_x*cam_tile));
 	const int32_t glide_y=int32_t(std::lround(transient_y+rest_y*cam_tile));
@@ -884,26 +943,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		return;
 
 	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);
-	std::set<std::pair<int32_t,int32_t>> current_coverage;
-	std::set<std::pair<int32_t,int32_t>> item_coverage;
-	std::set<std::pair<int32_t,int32_t>> vehicle_coverage;
-	std::set<std::pair<int32_t,int32_t>> main_coverage;
-	std::set<std::pair<int32_t,int32_t>> upper_coverage;
-	std::unordered_map<int32_t,uint16_t> selected;
-	for(const render_proxyst &proxy:proxies)
-		{
-		current_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		auto &layer_mask=selected[proxy.target_x*vp->dim_y+proxy.target_y];
-		layer_mask|=uint16_t(1U<<static_cast<uint8_t>(proxy.layer));
-		if(proxy.layer==viewport_creature_layer::item)
-			item_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		else if(proxy.layer==viewport_creature_layer::vehicle)
-			vehicle_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		else if(is_main_creature(proxy.layer))
-			main_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		else if(proxy.layer!=viewport_creature_layer::designation)
-			upper_coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
-		}
+	render_coveragest coverage=collect_coverage(proxies,vp->dim_y);
 
 	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
 	const int32_t zoom=renderer->viewport_zoom_factor;
@@ -939,41 +979,9 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		for(int32_t x=vp->clipx[0];x<=vp->clipx[1];++x)
 			{
 			for(int32_t y=vp->clipy[0];y<=vp->clipy[1];++y)
-				redraw_world_tile(renderer,vp,x,y,selected);
+				redraw_world_tile(renderer,vp,x,y,coverage.selected);
 			}
-		for(const render_proxyst &proxy:proxies)
-			{
-			if(proxy.layer==viewport_creature_layer::item)draw_proxy(renderer,proxy);
-			}
-		for(const auto &[x,y]:item_coverage)
-			redraw_above_base(
-				renderer,vp,x,y,viewport_creature_layer::item,selected);
-		for(const render_proxyst &proxy:proxies)
-			{
-			if(proxy.layer==viewport_creature_layer::vehicle)draw_proxy(renderer,proxy);
-			}
-		for(const auto &[x,y]:vehicle_coverage)
-			redraw_above_base(
-				renderer,vp,x,y,viewport_creature_layer::vehicle,selected);
-		for(const render_proxyst &proxy:proxies)
-			{
-			if(is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
-			}
-		for(const auto &[x,y]:main_coverage)
-			redraw_above_main(renderer,vp,x,y,selected);
-		for(const render_proxyst &proxy:proxies)
-			{
-			if(proxy.layer!=viewport_creature_layer::item&&
-				proxy.layer!=viewport_creature_layer::vehicle&&
-				proxy.layer!=viewport_creature_layer::designation&&
-				!is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
-			}
-		for(const auto &[x,y]:upper_coverage)
-			redraw_above_upper(renderer,vp,x,y,selected);
-		for(const render_proxyst &proxy:proxies)
-			{
-			if(proxy.layer==viewport_creature_layer::designation)draw_proxy(renderer,proxy);
-			}
+		draw_interpolation_stages(renderer,vp,proxies,coverage);
 		renderer->origin_x=saved_origin_x;
 		renderer->origin_y=saved_origin_y;
 		render_set_clip_rect(sdl_renderer,nullptr);
@@ -983,7 +991,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		return;
 		}
 
-	std::set<std::pair<int32_t,int32_t>> redraw_coverage=current_coverage;
+	std::set<std::pair<int32_t,int32_t>> redraw_coverage=coverage.all;
 	redraw_coverage.insert(previous_coverage.begin(),previous_coverage.end());
 	Uint8 old_r=0,old_g=0,old_b=0,old_a=255;
 	get_render_draw_color(sdl_renderer,&old_r,&old_g,&old_b,&old_a);
@@ -1004,41 +1012,11 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	for(const auto &[x,y]:redraw_coverage)
 		{
-		if(inside_clip(vp,x,y))redraw_world_tile(renderer,vp,x,y,selected);
+		if(inside_clip(vp,x,y))redraw_world_tile(renderer,vp,x,y,coverage.selected);
 		}
-	for(const render_proxyst &proxy:proxies)
-		{
-		if(proxy.layer==viewport_creature_layer::item)draw_proxy(renderer,proxy);
-		}
-	for(const auto &[x,y]:item_coverage)
-		redraw_above_base(renderer,vp,x,y,viewport_creature_layer::item,selected);
-	for(const render_proxyst &proxy:proxies)
-		{
-		if(proxy.layer==viewport_creature_layer::vehicle)draw_proxy(renderer,proxy);
-		}
-	for(const auto &[x,y]:vehicle_coverage)
-		redraw_above_base(renderer,vp,x,y,viewport_creature_layer::vehicle,selected);
-	for(const render_proxyst &proxy:proxies)
-		{
-		if(is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
-		}
-	for(const auto &[x,y]:main_coverage)
-		redraw_above_main(renderer,vp,x,y,selected);
-	for(const render_proxyst &proxy:proxies)
-		{
-		if(proxy.layer!=viewport_creature_layer::item&&
-			proxy.layer!=viewport_creature_layer::vehicle&&
-			proxy.layer!=viewport_creature_layer::designation&&
-			!is_main_creature(proxy.layer))draw_proxy(renderer,proxy);
-		}
-	for(const auto &[x,y]:upper_coverage)
-		redraw_above_upper(renderer,vp,x,y,selected);
-	for(const render_proxyst &proxy:proxies)
-		{
-		if(proxy.layer==viewport_creature_layer::designation)draw_proxy(renderer,proxy);
-		}
+	draw_interpolation_stages(renderer,vp,proxies,coverage);
 
-	previous_coverage=std::move(current_coverage);
+	previous_coverage=std::move(coverage.all);
 }
 
 struct renderer_hook : df::renderer_2d_base
@@ -1056,35 +1034,37 @@ void renderer_hook::interpose_fn_update_all()
 	INTERPOSE_NEXT(update_all)();
 }
 
+void clear_sdl_bindings()
+{
+	render_copy_f=nullptr;
+	render_fill_rect=nullptr;
+	render_set_clip_rect=nullptr;
+	get_render_draw_color=nullptr;
+	set_render_draw_color=nullptr;
+}
+
 bool load_sdl(color_ostream &out)
 {
-	sdl_handle=OpenPlugin(sdl_library);
-	if(sdl_handle==nullptr)
+	clear_sdl_bindings();
+	DFLibrary *handle=DFSDL::obtain_library_handle();
+	if(handle==nullptr)
 		{
-		out.printerr("smooth-movement: could not load SDL2\n");
+		out.printerr("smooth-movement: DFHack has no SDL2 library handle\n");
 		return false;
 		}
-	render_copy_f=reinterpret_cast<RenderCopyF>(
-		LookupPlugin(sdl_handle,"SDL_RenderCopyF"));
-	render_fill_rect=reinterpret_cast<RenderFillRect>(
-		LookupPlugin(sdl_handle,"SDL_RenderFillRect"));
-	render_set_clip_rect=reinterpret_cast<RenderSetClipRect>(
-		LookupPlugin(sdl_handle,"SDL_RenderSetClipRect"));
-	get_render_draw_color=reinterpret_cast<GetRenderDrawColor>(
-		LookupPlugin(sdl_handle,"SDL_GetRenderDrawColor"));
-	set_render_draw_color=reinterpret_cast<SetRenderDrawColor>(
-		LookupPlugin(sdl_handle,"SDL_SetRenderDrawColor"));
-	get_ticks=reinterpret_cast<GetTicks>(LookupPlugin(sdl_handle,"SDL_GetTicks"));
-	if(render_copy_f==nullptr||render_fill_rect==nullptr||
-		render_set_clip_rect==nullptr||
-		get_render_draw_color==nullptr||set_render_draw_color==nullptr||
-		get_ticks==nullptr)
-		{
-		out.printerr("smooth-movement: required SDL2 functions are unavailable\n");
-		ClosePlugin(sdl_handle);
-		sdl_handle=nullptr;
-		return false;
+	#define bind(name,target) \
+		target=reinterpret_cast<decltype(target)>(LookupPlugin(handle,#name)); \
+		if(target==nullptr) { \
+			out.printerr("smooth-movement: SDL2 function unavailable: " #name "\n"); \
+			clear_sdl_bindings(); \
+			return false; \
 		}
+	bind(SDL_RenderCopyF,render_copy_f);
+	bind(SDL_RenderFillRect,render_fill_rect);
+	bind(SDL_RenderSetClipRect,render_set_clip_rect);
+	bind(SDL_GetRenderDrawColor,get_render_draw_color);
+	bind(SDL_SetRenderDrawColor,set_render_draw_color);
+	#undef bind
 	return true;
 }
 
@@ -1195,8 +1175,7 @@ DFhackCExport command_result plugin_enable(color_ostream &out,bool enable)
 		if(!INTERPOSE_HOOK(renderer_hook,update_all).apply())
 			{
 			out.printerr("smooth-movement: could not hook the 2D renderer\n");
-			ClosePlugin(sdl_handle);
-			sdl_handle=nullptr;
+			clear_sdl_bindings();
 			return CR_FAILURE;
 			}
 		}
@@ -1204,13 +1183,7 @@ DFhackCExport command_result plugin_enable(color_ostream &out,bool enable)
 		{
 		INTERPOSE_HOOK(renderer_hook,update_all).remove();
 		reset_state();
-		if(sdl_handle!=nullptr)ClosePlugin(sdl_handle);
-		sdl_handle=nullptr;
-		render_copy_f=nullptr;
-		render_fill_rect=nullptr;
-		get_render_draw_color=nullptr;
-		set_render_draw_color=nullptr;
-		get_ticks=nullptr;
+		clear_sdl_bindings();
 		if(gps!=nullptr)++gps->force_full_display_count;
 		}
 	is_enabled=enable;

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -41,7 +41,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.3.1";
+constexpr const char *plugin_version="0.3.0";
 #ifdef WIN32
 constexpr const char *sdl_library="SDL2.dll";
 #else

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -10,6 +10,46 @@
 
 #include "visual_animation.h"
 
+namespace {
+
+viewport_visual_animation_inputst make_input(
+	const void *viewport,
+	int32_t dimension,
+	const int32_t *empty)
+{
+	viewport_visual_animation_inputst input;
+	input.viewport=viewport;
+	input.dim_x=dimension;
+	input.dim_y=dimension;
+	input.context_revision=1;
+	input.current.fill(empty);
+	input.previous.fill(empty);
+	return input;
+}
+
+void set_layer(
+	viewport_visual_animation_inputst &input,
+	viewport_visual_layer layer,
+	const int32_t *current,
+	const int32_t *previous)
+{
+	const size_t index=static_cast<size_t>(layer);
+	input.current[index]=current;
+	input.previous[index]=previous;
+}
+
+void run_frame(
+	visual_animation_managerst &manager,
+	const viewport_visual_animation_inputst &input,
+	uint32_t now_ms)
+{
+	manager.begin_frame(now_ms);
+	manager.synchronize_viewport(input,true);
+	manager.end_frame();
+}
+
+} // namespace
+
 int main()
 {
 	visual_animation_managerst manager;
@@ -33,88 +73,61 @@ int main()
 	std::array<int32_t,9> current{};
 	std::array<int32_t,9> previous{};
 	const void *viewport=reinterpret_cast<const void *>(uintptr_t(1));
-	viewport_visual_animation_inputst input=
-		{
-		viewport,
-		3,
-		3,
-		1,
-		{empty.data(),current.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data()},
-		{empty.data(),previous.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data(),empty.data()}
-		};
+	auto input=make_input(viewport,3,empty.data());
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
 
 	visual_animation_managerst movement;
-	movement.begin_frame(1990);
-	movement.synchronize_viewport(input,true);
-	movement.end_frame();
+	run_frame(movement,input,1990);
 	assert(!movement.requires_full_redraw());
 
 	previous[0*3+1]=42;
 	current[1*3+1]=42;
-	movement.begin_frame(2000);
-	movement.synchronize_viewport(input,true);
-	movement.end_frame();
-	auto render=movement.get_movement(viewport,viewport_creature_layer::center,1,1);
+	run_frame(movement,input,2000);
+	auto render=movement.get_movement(viewport,viewport_visual_layer::center,1,1);
 	assert(render.active);
 	assert(render.source_x==0&&render.source_y==1);
 	assert(render.progress==0.0f);
 	assert(movement.requires_full_redraw());
 
 	previous=current;
-	input.previous[1]=previous.data();
-	movement.begin_frame(2050);
-	movement.synchronize_viewport(input,true);
-	movement.end_frame();
-	render=movement.get_movement(viewport,viewport_creature_layer::center,1,1);
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
+	run_frame(movement,input,2050);
+	render=movement.get_movement(viewport,viewport_visual_layer::center,1,1);
 	assert(render.active);
 	assert(render.progress==0.5f);
 
-	movement.begin_frame(2100);
-	movement.synchronize_viewport(input,true);
-	movement.end_frame();
+	run_frame(movement,input,2100);
 	assert(!movement.get_movement(
-		viewport,viewport_creature_layer::center,1,1).active);
+		viewport,viewport_visual_layer::center,1,1).active);
 	assert(movement.requires_full_redraw());
 
-	movement.begin_frame(2120);
-	movement.synchronize_viewport(input,true);
-	movement.end_frame();
+	run_frame(movement,input,2120);
 	assert(!movement.requires_full_redraw());
 
 	visual_animation_managerst ambiguous;
-	ambiguous.begin_frame(2990);
-	ambiguous.synchronize_viewport(input,true);
-	ambiguous.end_frame();
+	run_frame(ambiguous,input,2990);
 	previous.fill(0);
 	previous[0*3+1]=42;
 	previous[1*3+0]=42;
-	input.previous[1]=previous.data();
-	ambiguous.begin_frame(3000);
-	ambiguous.synchronize_viewport(input,true);
-	ambiguous.end_frame();
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
+	run_frame(ambiguous,input,3000);
 	assert(!ambiguous.get_movement(
-		viewport,viewport_creature_layer::center,1,1).active);
+		viewport,viewport_visual_layer::center,1,1).active);
 
 	visual_animation_managerst context;
 	current.fill(0);
 	previous.fill(0);
-	context.begin_frame(4000);
-	context.synchronize_viewport(input,true);
-	context.end_frame();
+	run_frame(context,input,4000);
 	previous[0*3+1]=42;
 	current[1*3+1]=42;
-	context.begin_frame(4010);
-	context.synchronize_viewport(input,true);
-	context.end_frame();
+	run_frame(context,input,4010);
 	assert(context.get_movement(
-		viewport,viewport_creature_layer::center,1,1).active);
+		viewport,viewport_visual_layer::center,1,1).active);
 
 	++input.context_revision;
-	context.begin_frame(4020);
-	context.synchronize_viewport(input,true);
-	context.end_frame();
+	run_frame(context,input,4020);
 	assert(!context.get_movement(
-		viewport,viewport_creature_layer::center,1,1).active);
+		viewport,viewport_visual_layer::center,1,1).active);
 
 	// Camera-pan handling. window_x/window_y change at input time but the buffers shift on a later
 	// render frame, so the manager must (a) NOT create movements from the buffer shift itself (the
@@ -122,17 +135,12 @@ int main()
 	std::array<int32_t,9> pan_current{};
 	std::array<int32_t,9> pan_previous{};
 	std::array<int32_t,9> pan_empty{};
-	viewport_visual_animation_inputst pan_input=
-		{
-		viewport,
-		3,
-		3,
-		1,
-		{pan_empty.data(),pan_current.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
-		{pan_empty.data(),pan_previous.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data(),pan_empty.data()},
-		0,
-		0
-		};
+	auto pan_input=make_input(viewport,3,pan_empty.data());
+	set_layer(
+		pan_input,
+		viewport_visual_layer::center,
+		pan_current.data(),
+		pan_previous.data());
 
 	// FLOAT REGRESSION: a stationary creature, pan announced at frame A, buffers shift at frame B.
 	// Frame B's buffers look exactly like a real move ((1,1)->(0,1) with a unique source) — the
@@ -140,21 +148,15 @@ int main()
 	visual_animation_managerst floaty;
 	pan_previous[1*3+1]=42;
 	pan_current[1*3+1]=42;
-	floaty.begin_frame(4990);
-	floaty.synchronize_viewport(pan_input,true);
-	floaty.end_frame();
+	run_frame(floaty,pan_input,4990);
 	pan_input.pan_x=1;                   // frame A: window scrolled, buffers unchanged
-	floaty.begin_frame(5000);
-	floaty.synchronize_viewport(pan_input,true);
-	floaty.end_frame();
-	assert(!floaty.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	run_frame(floaty,pan_input,5000);
+	assert(!floaty.get_movement(viewport,viewport_visual_layer::center,1,1).active);
 	pan_previous[1*3+1]=42;              // frame B: buffers apply the shift
 	pan_current.fill(0);
 	pan_current[0*3+1]=42;
-	floaty.begin_frame(5010);
-	floaty.synchronize_viewport(pan_input,true);
-	floaty.end_frame();
-	assert(!floaty.get_movement(viewport,viewport_creature_layer::center,0,1).active);
+	run_frame(floaty,pan_input,5010);
+	assert(!floaty.get_movement(viewport,viewport_visual_layer::center,0,1).active);
 
 	// FOLLOW: an in-flight movement survives the announce frame untouched and is translated on the
 	// frame the buffers shift, so the sprite tracks the scrolled world.
@@ -162,33 +164,25 @@ int main()
 	pan_current.fill(0);
 	pan_previous.fill(0);
 	pan_input.pan_x=0;
-	panner.begin_frame(5990);
-	panner.synchronize_viewport(pan_input,true);
-	panner.end_frame();
+	run_frame(panner,pan_input,5990);
 	pan_previous[0*3+1]=42;              // creature steps (0,1) -> (1,1)
 	pan_current[1*3+1]=42;
-	panner.begin_frame(6000);
-	panner.synchronize_viewport(pan_input,true);
-	panner.end_frame();
-	auto moved=panner.get_movement(viewport,viewport_creature_layer::center,1,1);
+	run_frame(panner,pan_input,6000);
+	auto moved=panner.get_movement(viewport,viewport_visual_layer::center,1,1);
 	assert(moved.active&&moved.source_x==0&&moved.source_y==1);
 
 	pan_input.pan_x=1;                   // frame A: pan announced, buffers unchanged
 	pan_previous[0*3+1]=0;
 	pan_previous[1*3+1]=42;              // previous now matches current (stationary at (1,1))
-	panner.begin_frame(6010);
-	panner.synchronize_viewport(pan_input,true);
-	panner.end_frame();
-	moved=panner.get_movement(viewport,viewport_creature_layer::center,1,1);
+	run_frame(panner,pan_input,6010);
+	moved=panner.get_movement(viewport,viewport_visual_layer::center,1,1);
 	assert(moved.active&&moved.source_x==0);   // untouched: still anchored to the old frame
 
 	pan_current.fill(0);                 // frame B: buffers shift east by one
 	pan_current[0*3+1]=42;
-	panner.begin_frame(6020);
-	panner.synchronize_viewport(pan_input,true);
-	panner.end_frame();
-	assert(!panner.get_movement(viewport,viewport_creature_layer::center,1,1).active);
-	auto followed=panner.get_movement(viewport,viewport_creature_layer::center,0,1);
+	run_frame(panner,pan_input,6020);
+	assert(!panner.get_movement(viewport,viewport_visual_layer::center,1,1).active);
+	auto followed=panner.get_movement(viewport,viewport_visual_layer::center,0,1);
 	assert(followed.active&&followed.source_x==-1&&followed.source_y==1);
 
 	// SAME-FRAME: pan announced and buffers shifted in the same call — translated immediately.
@@ -196,23 +190,17 @@ int main()
 	pan_current.fill(0);
 	pan_previous.fill(0);
 	pan_input.pan_x=0;
-	same_frame.begin_frame(6990);
-	same_frame.synchronize_viewport(pan_input,true);
-	same_frame.end_frame();
+	run_frame(same_frame,pan_input,6990);
 	pan_previous[0*3+1]=42;
 	pan_current[1*3+1]=42;
-	same_frame.begin_frame(7000);
-	same_frame.synchronize_viewport(pan_input,true);
-	same_frame.end_frame();
-	assert(same_frame.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	run_frame(same_frame,pan_input,7000);
+	assert(same_frame.get_movement(viewport,viewport_visual_layer::center,1,1).active);
 	pan_input.pan_x=1;
 	pan_previous=pan_current;
 	pan_current.fill(0);
 	pan_current[0*3+1]=42;
-	same_frame.begin_frame(7010);
-	same_frame.synchronize_viewport(pan_input,true);
-	same_frame.end_frame();
-	followed=same_frame.get_movement(viewport,viewport_creature_layer::center,0,1);
+	run_frame(same_frame,pan_input,7010);
+	followed=same_frame.get_movement(viewport,viewport_visual_layer::center,0,1);
 	assert(followed.active&&followed.source_x==-1);
 
 	// A change that is NOT a pure pan (context revision bump) still resets, even with in-flight work.
@@ -221,20 +209,14 @@ int main()
 	pan_previous.fill(0);
 	pan_input.pan_x=0;
 	pan_input.context_revision=1;
-	reset_on_zoom.begin_frame(8000);
-	reset_on_zoom.synchronize_viewport(pan_input,true);
-	reset_on_zoom.end_frame();
+	run_frame(reset_on_zoom,pan_input,8000);
 	pan_previous[0*3+1]=42;
 	pan_current[1*3+1]=42;
-	reset_on_zoom.begin_frame(8010);
-	reset_on_zoom.synchronize_viewport(pan_input,true);
-	reset_on_zoom.end_frame();
-	assert(reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	run_frame(reset_on_zoom,pan_input,8010);
+	assert(reset_on_zoom.get_movement(viewport,viewport_visual_layer::center,1,1).active);
 	pan_input.context_revision=2;       // e.g. zoom / z-level / resize
-	reset_on_zoom.begin_frame(8020);
-	reset_on_zoom.synchronize_viewport(pan_input,true);
-	reset_on_zoom.end_frame();
-	assert(!reset_on_zoom.get_movement(viewport,viewport_creature_layer::center,1,1).active);
+	run_frame(reset_on_zoom,pan_input,8020);
+	assert(!reset_on_zoom.get_movement(viewport,viewport_visual_layer::center,1,1).active);
 
 	// Status fragments inherit nearby center motion even while their texture flashes.
 	std::array<int32_t,9> status_current{};
@@ -244,16 +226,15 @@ int main()
 	input.context_revision=1;
 	input.current.fill(empty.data());
 	input.previous.fill(empty.data());
-	input.current[static_cast<size_t>(viewport_creature_layer::center)]=current.data();
-	input.previous[static_cast<size_t>(viewport_creature_layer::center)]=previous.data();
-	input.current[static_cast<size_t>(viewport_creature_layer::item)]=status_current.data();
-	input.previous[static_cast<size_t>(viewport_creature_layer::item)]=status_previous.data();
-	input.current[static_cast<size_t>(viewport_creature_layer::designation)]=status_current.data();
-	input.previous[static_cast<size_t>(viewport_creature_layer::designation)]=status_previous.data();
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
+	set_layer(input,viewport_visual_layer::item,status_current.data(),status_previous.data());
+	set_layer(
+		input,
+		viewport_visual_layer::designation,
+		status_current.data(),
+		status_previous.data());
 	visual_animation_managerst companion;
-	companion.begin_frame(8990);
-	companion.synchronize_viewport(input,true);
-	companion.end_frame();
+	run_frame(companion,input,8990);
 	previous[0*3+1]=42;
 	current[1*3+1]=42;
 	status_previous[0*3+0]=90;
@@ -264,20 +245,16 @@ int main()
 	assert(!visual_moved_between_tiles(
 		status_current.data(),status_previous.data(),0*3+0,1*3+0));
 	status_previous[1*3+0]=0;
-	companion.begin_frame(9000);
-	companion.synchronize_viewport(input,true);
-	companion.end_frame();
-	auto status=companion.get_movement(viewport,viewport_creature_layer::designation,1,0);
+	run_frame(companion,input,9000);
+	auto status=companion.get_movement(viewport,viewport_visual_layer::designation,1,0);
 	assert(status.active&&status.source_x==0&&status.source_y==0);
 	const auto carried_item=companion.get_movement(
-		viewport,viewport_creature_layer::item,1,0);
+		viewport,viewport_visual_layer::item,1,0);
 	assert(carried_item.active&&carried_item.inherited);
 	previous=current;
 	status_current[1*3+0]=92;
-	companion.begin_frame(9050);
-	companion.synchronize_viewport(input,true);
-	companion.end_frame();
-	status=companion.get_movement(viewport,viewport_creature_layer::designation,1,0);
+	run_frame(companion,input,9050);
+	status=companion.get_movement(viewport,viewport_visual_layer::designation,1,0);
 	assert(status.active&&status.progress==0.5f);
 
 	// Divergent nearby creature movements make companion ownership ambiguous, so the overlay snaps.
@@ -285,38 +262,29 @@ int main()
 	previous.fill(0);
 	status_current.fill(0);
 	visual_animation_managerst crowd;
-	crowd.begin_frame(9990);
-	crowd.synchronize_viewport(input,true);
-	crowd.end_frame();
+	run_frame(crowd,input,9990);
 	previous[0*3+0]=41;
 	current[0*3+1]=41;
 	previous[2*3+2]=42;
 	current[2*3+1]=42;
 	status_current[1*3+1]=99;
-	crowd.begin_frame(10000);
-	crowd.synchronize_viewport(input,true);
-	crowd.end_frame();
+	run_frame(crowd,input,10000);
 	assert(!crowd.get_movement(
-		viewport,viewport_creature_layer::designation,1,1).active);
+		viewport,viewport_visual_layer::designation,1,1).active);
 
 	// Wheelbarrows use the item layer and the same independent adjacent-movement detection.
 	current.fill(0);
 	previous.fill(0);
 	input.current.fill(empty.data());
 	input.previous.fill(empty.data());
-	input.current[static_cast<size_t>(viewport_creature_layer::item)]=current.data();
-	input.previous[static_cast<size_t>(viewport_creature_layer::item)]=previous.data();
+	set_layer(input,viewport_visual_layer::item,current.data(),previous.data());
 	visual_animation_managerst item;
-	item.begin_frame(10990);
-	item.synchronize_viewport(input,true);
-	item.end_frame();
+	run_frame(item,input,10990);
 	previous[0*3+1]=77;
 	current[1*3+1]=77;
-	item.begin_frame(11000);
-	item.synchronize_viewport(input,true);
-	item.end_frame();
+	run_frame(item,input,11000);
 	const auto item_move=item.get_movement(
-		viewport,viewport_creature_layer::item,1,1);
+		viewport,viewport_visual_layer::item,1,1);
 	assert(item_move.active&&item_move.source_x==0&&item_move.source_y==1);
 
 	// Minecart graphics can change texpos while moving; vehicle identity is tile occupancy.
@@ -324,35 +292,26 @@ int main()
 	previous.fill(0);
 	input.current.fill(empty.data());
 	input.previous.fill(empty.data());
-	input.current[static_cast<size_t>(viewport_creature_layer::vehicle)]=current.data();
-	input.previous[static_cast<size_t>(viewport_creature_layer::vehicle)]=previous.data();
+	set_layer(input,viewport_visual_layer::vehicle,current.data(),previous.data());
 	visual_animation_managerst vehicle;
-	vehicle.begin_frame(11990);
-	vehicle.synchronize_viewport(input,true);
-	vehicle.end_frame();
+	run_frame(vehicle,input,11990);
 	previous[0*3+1]=77;
 	current[1*3+1]=78;
-	vehicle.begin_frame(12000);
-	vehicle.synchronize_viewport(input,true);
-	vehicle.end_frame();
+	run_frame(vehicle,input,12000);
 	assert(vehicle.get_movement(
-		viewport,viewport_creature_layer::vehicle,1,1).active);
+		viewport,viewport_visual_layer::vehicle,1,1).active);
 	previous=current;
 	current[1*3+1]=79;
-	vehicle.begin_frame(12050);
-	vehicle.synchronize_viewport(input,true);
-	vehicle.end_frame();
+	run_frame(vehicle,input,12050);
 	const auto cart=vehicle.get_movement(
-		viewport,viewport_creature_layer::vehicle,1,1);
+		viewport,viewport_visual_layer::vehicle,1,1);
 	assert(cart.active&&cart.progress==0.5f);
 	previous=current;
 	current.fill(0);
 	current[2*3+1]=80;
-	vehicle.begin_frame(12060);
-	vehicle.synchronize_viewport(input,true);
-	vehicle.end_frame();
+	run_frame(vehicle,input,12060);
 	const auto chained=vehicle.get_movement(
-		viewport,viewport_creature_layer::vehicle,2,1);
+		viewport,viewport_visual_layer::vehicle,2,1);
 	assert(chained.active&&chained.source_x>0.0f&&chained.source_x<1.0f&&
 		chained.progress==0.0f);
 }

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -240,14 +240,24 @@ int main()
 	status_previous[0*3+0]=90;
 	status_current[1*3+0]=91;
 	assert(visual_moved_between_tiles(
+		viewport_visual_layer::designation,
+		status_current.data(),status_previous.data(),0*3+0,1*3+0));
+	status_previous[0*3+0]=0;
+	assert(visual_moved_between_tiles(
+		viewport_visual_layer::designation,
+		status_current.data(),status_previous.data(),0*3+0,1*3+0));
+	assert(!visual_moved_between_tiles(
+		viewport_visual_layer::item,
 		status_current.data(),status_previous.data(),0*3+0,1*3+0));
 	status_previous[1*3+0]=80;
 	assert(!visual_moved_between_tiles(
+		viewport_visual_layer::designation,
 		status_current.data(),status_previous.data(),0*3+0,1*3+0));
+	status_previous[0*3+0]=90;
 	status_previous[1*3+0]=0;
 	run_frame(companion,input,9000);
 	auto status=companion.get_movement(viewport,viewport_visual_layer::designation,1,0);
-	assert(status.active&&status.source_x==0&&status.source_y==0);
+	assert(status.active&&!status.inherited&&status.source_x==0&&status.source_y==0);
 	const auto carried_item=companion.get_movement(
 		viewport,viewport_visual_layer::item,1,0);
 	assert(carried_item.active&&carried_item.inherited);
@@ -261,6 +271,7 @@ int main()
 	current.fill(0);
 	previous.fill(0);
 	status_current.fill(0);
+	status_previous.fill(0);
 	visual_animation_managerst crowd;
 	run_frame(crowd,input,9990);
 	previous[0*3+0]=41;
@@ -271,6 +282,13 @@ int main()
 	run_frame(crowd,input,10000);
 	assert(!crowd.get_movement(
 		viewport,viewport_visual_layer::designation,1,1).active);
+	status_previous[1*3+0]=90;
+	status_current[1*3+1]=91;
+	run_frame(crowd,input,10010);
+	status=crowd.get_movement(viewport,viewport_visual_layer::designation,1,1);
+	assert(status.active);
+	assert(!status.inherited);
+	assert(status.source_x==1&&status.source_y==0);
 
 	// Wheelbarrows use the item layer and the same independent adjacent-movement detection.
 	current.fill(0);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -114,6 +114,23 @@ int main()
 	assert(!ambiguous.get_movement(
 		viewport,viewport_visual_layer::center,1,1).active);
 
+	// A handler and led animal form an occupied chain: each enters the other's old space.
+	visual_animation_managerst convoy;
+	current.fill(0);
+	previous.fill(0);
+	run_frame(convoy,input,3490);
+	previous[0*3+1]=41;
+	previous[1*3+1]=42;
+	current[1*3+1]=41;
+	current[2*3+1]=42;
+	run_frame(convoy,input,3500);
+	const auto animal=convoy.get_movement(
+		viewport,viewport_visual_layer::center,1,1);
+	const auto handler=convoy.get_movement(
+		viewport,viewport_visual_layer::center,2,1);
+	assert(animal.active&&animal.source_x==0&&animal.source_y==1);
+	assert(handler.active&&handler.source_x==1&&handler.source_y==1);
+
 	visual_animation_managerst context;
 	current.fill(0);
 	previous.fill(0);

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -9,7 +9,7 @@
 #include <cstdlib>
 #include <vector>
 
-enum class viewport_creature_layer : uint8_t
+enum class viewport_visual_layer : uint8_t
 {
 	right,
 	center,
@@ -23,14 +23,31 @@ enum class viewport_creature_layer : uint8_t
 	count
 };
 
+constexpr bool visual_layer_moves_independently(viewport_visual_layer layer)
+{
+	return layer==viewport_visual_layer::center||
+		layer==viewport_visual_layer::vehicle||
+		layer==viewport_visual_layer::item;
+}
+
+constexpr bool visual_layer_matches(
+	viewport_visual_layer layer,
+	int32_t current,
+	int32_t previous)
+{
+	return layer==viewport_visual_layer::vehicle?
+		previous!=0:
+		previous==current;
+}
+
 struct viewport_visual_animation_inputst
 {
 	const void *viewport=nullptr;
 	int32_t dim_x=0;
 	int32_t dim_y=0;
 	uint64_t context_revision=0;
-	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> current{};
-	std::array<const int32_t *,static_cast<size_t>(viewport_creature_layer::count)> previous{};
+	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> current{};
+	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> previous{};
 	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision.
 	// The scroll value is only a HINT: it changes at input time, while the viewport buffers shift
 	// on a later render frame. The manager hypothesis-tests the buffers to find the frame the
@@ -74,7 +91,7 @@ class visual_animation_managerst
 {
 	struct movementst
 	{
-		viewport_creature_layer layer;
+		viewport_visual_layer layer;
 		int32_t texpos;
 		float source_x;
 		float source_y;
@@ -85,47 +102,49 @@ class visual_animation_managerst
 
 	struct viewport_animationst
 	{
-		const void *viewport;
-		int32_t dim_x;
-		int32_t dim_y;
-		uint64_t context_revision;
-		bool has_context;
-		bool seen;
+		const void *viewport=nullptr;
+		int32_t dim_x=0;
+		int32_t dim_y=0;
+		uint64_t context_revision=0;
+		bool has_context=false;
+		bool seen=false;
 		std::vector<movementst> movements;
-		int32_t pan_x;
-		int32_t pan_y;
-		bool has_pan;
+		int32_t pan_x=0;
+		int32_t pan_y=0;
+		bool has_pan=false;
 		// Window-scroll delta not yet observed in the buffers, and how long it has been pending.
-		int32_t pending_dx;
-		int32_t pending_dy;
-		int32_t pending_frames;
+		int32_t pending_dx=0;
+		int32_t pending_dy=0;
+		int32_t pending_frames=0;
 		// Frames left in which new-movement detection stays suppressed after scroll activity.
-		int32_t suppress_frames;
+		int32_t suppress_frames=0;
 	};
 
-	uint32_t frame_time_ms;
-	uint32_t frame_delta_ms;
-	bool has_frame;
-	bool force_full_redraw;
+	uint32_t frame_time_ms=0;
+	uint32_t frame_delta_ms=0;
+	bool has_frame=false;
+	bool force_full_redraw=false;
 	std::vector<viewport_animationst> viewports;
 
 	static constexpr uint32_t movement_duration_ms=100;
 
-	static bool independently_moving(viewport_creature_layer layer)
+	static void clear_pending(viewport_animationst &state)
 		{
-		return layer==viewport_creature_layer::center||
-			layer==viewport_creature_layer::vehicle||
-			layer==viewport_creature_layer::item;
+		state.pending_dx=0;
+		state.pending_dy=0;
+		state.pending_frames=0;
 		}
 
-	static bool same_visual(
-		viewport_creature_layer layer,
-		int32_t current,
-		int32_t previous)
+	static void abandon_pending(viewport_animationst &state)
 		{
-		return layer==viewport_creature_layer::vehicle?
-			previous!=0:
-			previous==current;
+		state.movements.clear();
+		clear_pending(state);
+		}
+
+	static void reset_tracking(viewport_animationst &state)
+		{
+		abandon_pending(state);
+		state.suppress_frames=0;
 		}
 
 	viewport_animationst &get_viewport(const viewport_visual_animation_inputst &input)
@@ -134,7 +153,7 @@ class visual_animation_managerst
 			{
 			if(state.viewport==input.viewport)return state;
 			}
-		viewports.push_back({input.viewport,0,0,0,false,false,{},0,0,false,0,0,0,0});
+		viewports.push_back({input.viewport});
 		return viewports.back();
 		}
 
@@ -145,13 +164,7 @@ class visual_animation_managerst
 		}
 
 	public:
-		visual_animation_managerst()
-			{
-			frame_time_ms=0;
-			frame_delta_ms=0;
-			has_frame=false;
-			force_full_redraw=false;
-			}
+		visual_animation_managerst()=default;
 
 		void begin_frame(uint32_t now_ms)
 			{
@@ -175,7 +188,7 @@ class visual_animation_managerst
 
 			if(!input.valid())
 				{
-				state.movements.clear();
+				reset_tracking(state);
 				state.has_context=false;
 				return;
 				}
@@ -207,11 +220,7 @@ class visual_animation_managerst
 			state.has_pan=true;
 			if(context_changed||!allow_new_movements)
 				{
-				state.movements.clear();
-				state.pending_dx=0;
-				state.pending_dy=0;
-				state.pending_frames=0;
-				state.suppress_frames=0;
+				reset_tracking(state);
 				return;
 				}
 
@@ -227,8 +236,8 @@ class visual_animation_managerst
 				int32_t matches=0;
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
-					if(!independently_moving(
-						static_cast<viewport_creature_layer>(layer)))continue;
+					if(!visual_layer_moves_independently(
+						static_cast<viewport_visual_layer>(layer)))continue;
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
 					for(int32_t x=0;x<input.dim_x;++x)
@@ -242,8 +251,8 @@ class visual_animation_managerst
 							const int32_t sy=y+dwy;
 							if(sy<0||sy>=input.dim_y)continue;
 							++considered;
-							if(same_visual(
-								static_cast<viewport_creature_layer>(layer),
+						if(visual_layer_matches(
+								static_cast<viewport_visual_layer>(layer),
 								texpos,
 								previous[sx*input.dim_y+sy]))++matches;
 							}
@@ -252,10 +261,7 @@ class visual_animation_managerst
 				if(considered==0)
 					{
 					// Nothing visible to anchor the test on: nothing to animate either.
-					state.movements.clear();
-					state.pending_dx=0;
-					state.pending_dy=0;
-					state.pending_frames=0;
+					abandon_pending(state);
 					}
 				else if(matches*2>=considered)
 					{
@@ -275,19 +281,14 @@ class visual_animation_managerst
 									movement.target_y<0||movement.target_y>=input.dim_y;
 								}),
 						state.movements.end());
-					state.pending_dx=0;
-					state.pending_dy=0;
-					state.pending_frames=0;
+					clear_pending(state);
 					translated=true;
 					}
 				else if(++state.pending_frames>4)
 					{
 					// The shift never showed up recognizably (heavy simultaneous movement, culled
 					// render, ...): fall back to the safe reset behavior.
-					state.movements.clear();
-					state.pending_dx=0;
-					state.pending_dy=0;
-					state.pending_frames=0;
+					abandon_pending(state);
 					}
 				}
 
@@ -300,8 +301,8 @@ class visual_animation_managerst
 				std::vector<uint8_t> claimed_sources(tile_count);
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
-					if(!independently_moving(
-						static_cast<viewport_creature_layer>(layer)))continue;
+					if(!visual_layer_moves_independently(
+						static_cast<viewport_visual_layer>(layer)))continue;
 					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
@@ -328,8 +329,8 @@ class visual_animation_managerst
 										source_y<0||source_y>=input.dim_y)continue;
 									const int32_t candidate=source_x*input.dim_y+source_y;
 								if(!claimed_sources[candidate]&&
-									same_visual(
-										static_cast<viewport_creature_layer>(layer),
+									visual_layer_matches(
+										static_cast<viewport_visual_layer>(layer),
 										texpos,
 										previous[candidate])&&
 									current[candidate]==0)
@@ -347,7 +348,7 @@ class visual_animation_managerst
 							for(const movementst &movement:state.movements)
 								{
 								if(movement.layer!=
-										static_cast<viewport_creature_layer>(layer)||
+										static_cast<viewport_visual_layer>(layer)||
 									movement.target_x!=visual_source_x||
 									movement.target_y!=visual_source_y)continue;
 								const float progress=
@@ -360,7 +361,7 @@ class visual_animation_managerst
 								}
 							state.movements.push_back(
 								{
-								static_cast<viewport_creature_layer>(layer),
+								static_cast<viewport_visual_layer>(layer),
 								texpos,
 								visual_source_x,
 								visual_source_y,
@@ -383,7 +384,7 @@ class visual_animation_managerst
 						const int32_t current=input.current[layer][target];
 						return frame_time_ms-movement.start_time_ms>=movement_duration_ms||
 							current==0||
-							!same_visual(movement.layer,current,movement.texpos);
+							!visual_layer_matches(movement.layer,current,movement.texpos);
 						}),
 				state.movements.end());
 			if(!state.movements.empty())force_full_redraw=true;
@@ -420,7 +421,7 @@ class visual_animation_managerst
 
 		visual_movement_renderst get_movement(
 			const void *viewport,
-			viewport_creature_layer layer,
+			viewport_visual_layer layer,
 			int32_t target_x,
 			int32_t target_y) const
 			{
@@ -440,9 +441,9 @@ class visual_animation_managerst
 							movement_progress(movement.start_time_ms)
 							};
 						}
-					if(layer==viewport_creature_layer::vehicle||
-						layer==viewport_creature_layer::center||
-						movement.layer!=viewport_creature_layer::center||
+					if(layer==viewport_visual_layer::vehicle||
+						layer==viewport_visual_layer::center||
+						movement.layer!=viewport_visual_layer::center||
 						std::abs(movement.target_x-target_x)>1||
 						std::abs(movement.target_y-target_y)>1)continue;
 					if(companion!=nullptr&&

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -23,17 +23,91 @@ enum class viewport_visual_layer : uint8_t
 	count
 };
 
+enum class visual_render_groupst : uint8_t
+{
+	item,
+	vehicle,
+	main,
+	upper,
+	designation,
+	count
+};
+
+struct visual_layer_descriptorst
+{
+	viewport_visual_layer layer;
+	visual_render_groupst render_group;
+	bool moves_independently;
+	bool matches_any_previous;
+	uint8_t draw_order;
+};
+
+constexpr std::array visual_layer_descriptors=
+	{
+	visual_layer_descriptorst{viewport_visual_layer::right,
+		visual_render_groupst::main,false,false,3},
+	visual_layer_descriptorst{viewport_visual_layer::center,
+		visual_render_groupst::main,true,false,0},
+	visual_layer_descriptorst{viewport_visual_layer::left,
+		visual_render_groupst::main,false,false,4},
+	visual_layer_descriptorst{viewport_visual_layer::upright,
+		visual_render_groupst::upper,false,false,5},
+	visual_layer_descriptorst{viewport_visual_layer::up,
+		visual_render_groupst::upper,false,false,6},
+	visual_layer_descriptorst{viewport_visual_layer::upleft,
+		visual_render_groupst::upper,false,false,7},
+	visual_layer_descriptorst{viewport_visual_layer::vehicle,
+		visual_render_groupst::vehicle,true,true,2},
+	visual_layer_descriptorst{viewport_visual_layer::item,
+		visual_render_groupst::item,true,false,1},
+	visual_layer_descriptorst{viewport_visual_layer::designation,
+		visual_render_groupst::designation,false,true,8}
+	};
+
+constexpr bool valid_visual_layer_descriptors()
+{
+	uint16_t draw_orders=0;
+	for(size_t i=0;i<visual_layer_descriptors.size();++i)
+		{
+		const auto &descriptor=visual_layer_descriptors[i];
+		if(static_cast<size_t>(descriptor.layer)!=i||
+			descriptor.draw_order>=visual_layer_descriptors.size()||
+			(draw_orders&(1U<<descriptor.draw_order)))return false;
+		draw_orders|=uint16_t(1U<<descriptor.draw_order);
+		}
+	return true;
+}
+
+static_assert(valid_visual_layer_descriptors());
+
+constexpr const visual_layer_descriptorst &visual_layer_descriptor(
+	viewport_visual_layer layer)
+{
+	return visual_layer_descriptors[static_cast<size_t>(layer)];
+}
+
+constexpr viewport_visual_layer visual_layer_at_draw_order(uint8_t draw_order)
+{
+	for(const auto &descriptor:visual_layer_descriptors)
+		if(descriptor.draw_order==draw_order)return descriptor.layer;
+	return viewport_visual_layer::count;
+}
+
+constexpr visual_render_groupst visual_render_group(viewport_visual_layer layer)
+{
+	return visual_layer_descriptor(layer).render_group;
+}
+
 constexpr bool visual_layer_moves_independently(viewport_visual_layer layer)
 {
-	return layer==viewport_visual_layer::center||
-		layer==viewport_visual_layer::vehicle||
-		layer==viewport_visual_layer::item;
+	return visual_layer_descriptor(layer).moves_independently;
 }
 
 constexpr bool visual_layer_tracks_own_movement(viewport_visual_layer layer)
 {
-	return visual_layer_moves_independently(layer)||
-		layer==viewport_visual_layer::designation;
+	const auto &descriptor=visual_layer_descriptor(layer);
+	return descriptor.moves_independently||
+		descriptor.render_group==visual_render_groupst::designation;
 }
 
 constexpr bool visual_layer_matches(
@@ -41,8 +115,7 @@ constexpr bool visual_layer_matches(
 	int32_t current,
 	int32_t previous)
 {
-	return layer==viewport_visual_layer::vehicle||
-		layer==viewport_visual_layer::designation?
+	return visual_layer_descriptor(layer).matches_any_previous?
 		previous!=0:
 		previous==current;
 }

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -30,12 +30,19 @@ constexpr bool visual_layer_moves_independently(viewport_visual_layer layer)
 		layer==viewport_visual_layer::item;
 }
 
+constexpr bool visual_layer_tracks_own_movement(viewport_visual_layer layer)
+{
+	return visual_layer_moves_independently(layer)||
+		layer==viewport_visual_layer::designation;
+}
+
 constexpr bool visual_layer_matches(
 	viewport_visual_layer layer,
 	int32_t current,
 	int32_t previous)
 {
-	return layer==viewport_visual_layer::vehicle?
+	return layer==viewport_visual_layer::vehicle||
+		layer==viewport_visual_layer::designation?
 		previous!=0:
 		previous==current;
 }
@@ -79,12 +86,14 @@ struct visual_movement_renderst
 };
 
 inline bool visual_moved_between_tiles(
+	viewport_visual_layer layer,
 	const int32_t *current,
 	const int32_t *previous,
 	int32_t source,
 	int32_t target)
 {
-	return previous[source]!=0&&previous[target]==0&&current[source]==0;
+	return previous[target]==0&&current[source]==0&&
+		(layer==viewport_visual_layer::designation||previous[source]!=0);
 }
 
 class visual_animation_managerst
@@ -153,7 +162,8 @@ class visual_animation_managerst
 			{
 			if(state.viewport==input.viewport)return state;
 			}
-		viewports.push_back({input.viewport});
+		viewports.emplace_back();
+		viewports.back().viewport=input.viewport;
 		return viewports.back();
 		}
 
@@ -236,7 +246,7 @@ class visual_animation_managerst
 				int32_t matches=0;
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
-					if(!visual_layer_moves_independently(
+					if(!visual_layer_tracks_own_movement(
 						static_cast<viewport_visual_layer>(layer)))continue;
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
@@ -301,7 +311,7 @@ class visual_animation_managerst
 				std::vector<uint8_t> claimed_sources(tile_count);
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
-					if(!visual_layer_moves_independently(
+					if(!visual_layer_tracks_own_movement(
 						static_cast<viewport_visual_layer>(layer)))continue;
 					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
 					const int32_t *current=input.current[layer];
@@ -429,6 +439,7 @@ class visual_animation_managerst
 				{
 				if(state.viewport!=viewport)continue;
 				const movementst *companion=nullptr;
+				bool ambiguous=false;
 				for(const movementst &movement:state.movements)
 					{
 					if(movement.layer==layer&&movement.target_x==target_x&&
@@ -452,9 +463,11 @@ class visual_animation_managerst
 						companion->source_y-companion->target_y!=
 							movement.source_y-movement.target_y||
 						companion->start_time_ms!=movement.start_time_ms))
-						return {};
-					companion=&movement;
+						ambiguous=true;
+					else if(companion==nullptr)
+						companion=&movement;
 					}
+				if(ambiguous)return {};
 				if(companion!=nullptr)
 					return {
 						true,

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -156,6 +156,47 @@ class visual_animation_managerst
 		state.suppress_frames=0;
 		}
 
+	static std::array<int32_t,2> shared_movement_delta(
+		const int32_t *current,
+		const int32_t *previous,
+		int32_t dim_x,
+		int32_t dim_y)
+		{
+		std::array<int32_t,2> best{};
+		int32_t best_count=1;
+		bool ambiguous=false;
+		for(int32_t dx=-1;dx<=1;++dx)
+			{
+			for(int32_t dy=-1;dy<=1;++dy)
+				{
+				if(dx==0&&dy==0)continue;
+				int32_t count=0;
+				for(int32_t x=0;x<dim_x;++x)
+					{
+					const int32_t source_x=x+dx;
+					if(source_x<0||source_x>=dim_x)continue;
+					for(int32_t y=0;y<dim_y;++y)
+						{
+						const int32_t source_y=y+dy;
+						if(source_y<0||source_y>=dim_y)continue;
+						const int32_t target=x*dim_y+y;
+						const int32_t texpos=current[target];
+						if(texpos!=0&&previous[target]!=texpos&&
+							previous[source_x*dim_y+source_y]==texpos)++count;
+						}
+					}
+				if(count>best_count)
+					{
+					best_count=count;
+					best={dx,dy};
+					ambiguous=false;
+					}
+				else if(count==best_count&&count>1)ambiguous=true;
+				}
+			}
+		return ambiguous?std::array<int32_t,2>{}:best;
+		}
+
 	viewport_animationst &get_viewport(const viewport_visual_animation_inputst &input)
 		{
 		for(viewport_animationst &state:viewports)
@@ -309,6 +350,7 @@ class visual_animation_managerst
 				{
 				const int32_t tile_count=input.dim_x*input.dim_y;
 				std::vector<uint8_t> claimed_sources(tile_count);
+				const size_t existing_movement_count=state.movements.size();
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
 					if(!visual_layer_tracks_own_movement(
@@ -316,37 +358,60 @@ class visual_animation_managerst
 					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
 					const int32_t *current=input.current[layer];
 					const int32_t *previous=input.previous[layer];
+					const auto shared_delta=
+						static_cast<viewport_visual_layer>(layer)==viewport_visual_layer::center?
+						shared_movement_delta(
+							current,previous,input.dim_x,input.dim_y):
+						std::array<int32_t,2>{};
 					for(int32_t x=0;x<input.dim_x;++x)
 						{
 						for(int32_t y=0;y<input.dim_y;++y)
 							{
 							const int32_t target=x*input.dim_y+y;
 							const int32_t texpos=current[target];
-							// Entity ids are unavailable, so only accept a unique
-							// same-sprite move between empty cells in one layer.
-							if(texpos==0||previous[target]!=0)continue;
+							if(texpos==0)continue;
 
 							int32_t source=-1;
 							int32_t candidate_count=0;
-							for(int32_t dx=-1;dx<=1;++dx)
+							if(shared_delta[0]!=0||shared_delta[1]!=0)
 								{
-								for(int32_t dy=-1;dy<=1;++dy)
+								const int32_t source_x=x+shared_delta[0];
+								const int32_t source_y=y+shared_delta[1];
+								if(source_x>=0&&source_x<input.dim_x&&
+									source_y>=0&&source_y<input.dim_y)
 									{
-									if(dx==0&&dy==0)continue;
-									const int32_t source_x=x+dx;
-									const int32_t source_y=y+dy;
-									if(source_x<0||source_x>=input.dim_x||
-										source_y<0||source_y>=input.dim_y)continue;
 									const int32_t candidate=source_x*input.dim_y+source_y;
-								if(!claimed_sources[candidate]&&
-									visual_layer_matches(
-										static_cast<viewport_visual_layer>(layer),
-										texpos,
-										previous[candidate])&&
-									current[candidate]==0)
+									if(!claimed_sources[candidate]&&previous[target]!=texpos&&
+										previous[candidate]==texpos)
 										{
 										source=candidate;
-										++candidate_count;
+										candidate_count=1;
+										}
+									}
+								}
+							// Otherwise require a unique same-sprite move between empty cells.
+							if(candidate_count==0&&previous[target]==0)
+								{
+								for(int32_t dx=-1;dx<=1;++dx)
+									{
+									for(int32_t dy=-1;dy<=1;++dy)
+										{
+										if(dx==0&&dy==0)continue;
+										const int32_t source_x=x+dx;
+										const int32_t source_y=y+dy;
+										if(source_x<0||source_x>=input.dim_x||
+											source_y<0||source_y>=input.dim_y)continue;
+										const int32_t candidate=source_x*input.dim_y+source_y;
+										if(!claimed_sources[candidate]&&
+											visual_layer_matches(
+												static_cast<viewport_visual_layer>(layer),
+												texpos,
+												previous[candidate])&&
+											current[candidate]==0)
+											{
+											source=candidate;
+											++candidate_count;
+											}
 										}
 									}
 								}
@@ -355,8 +420,9 @@ class visual_animation_managerst
 							claimed_sources[source]=1;
 							float visual_source_x=float(source/input.dim_y);
 							float visual_source_y=float(source%input.dim_y);
-							for(const movementst &movement:state.movements)
+							for(size_t i=0;i<existing_movement_count;++i)
 								{
+								const movementst &movement=state.movements[i];
 								if(movement.layer!=
 										static_cast<viewport_visual_layer>(layer)||
 									movement.target_x!=visual_source_x||


### PR DESCRIPTION
## Summary

- centralize rendering state, redraw stages, viewport metadata, and SDL integration
- animate creature status and designation overlays, including flashing texture fragments
- animate chained occupied creatures, such as a dwarf leading an animal, using their shared movement delta
- keep compatibility with DFHack 53.15-r2 and report plugin version 0.3.0

## Validation

- built smooth-movement and smooth-movement-test against DFHack 53.15-r2
- ran the smooth-movement-test executable successfully
- manually verified animated status balloons
- manually verified that both a dwarf and the animal it leads animate while moving