### PR TITLE
Feature/directional sprite flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   clothing and equipment flip with the creature because Dwarf Fortress
   composites them into a single tile sprite. Multi-tile creatures mirror as
   one composite, reflected about their anchor tile. Items, vehicles, and
-  designations are never mirrored. Enabled by default; toggle with
-  `smooth-movement flip on|off`.
+  designations are never mirrored. Off by default; turn it on with
+  `smooth-movement flip on`.
 
 ## 0.3.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Mirror creature sprites horizontally so they face their direction of travel.
+  Dwarf Fortress creature art natively faces west, so only creatures moving
+  east are mirrored. Facing is sticky: only horizontal movement changes it,
+  so walking north or south, and standing still, keep the last facing. Worn
+  clothing and equipment flip with the creature because Dwarf Fortress
+  composites them into a single tile sprite. Multi-tile creatures mirror as
+  one composite, reflected about their anchor tile. Items, vehicles, and
+  designations are never mirrored. Enabled by default; toggle with
+  `smooth-movement flip on|off`.
+
 ## 0.3.0 - 2026-08-03
 
 - Target DFHack `develop` and reuse DFHack's SDL library handle instead of

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
   unsafe layer reconstruction.
 - UI and menus are rendered after interpolated world sprites.
 
-## Directional sprite flipping (on by default)
+## Directional sprite flipping (off by default)
 
 Creature sprites mirror horizontally to face their direction of travel.
 Dwarf Fortress creature art natively faces west; a creature moving east is
@@ -97,7 +97,7 @@ into a single tile sprite before the plugin sees it. Multi-tile creatures
 mirror as one composite, reflected about their anchor tile. Items, vehicles,
 and designations are never mirrored.
 
-Toggle it with `smooth-movement flip on|off`; `smooth-movement flip` alone
+Turn it on with `smooth-movement flip on`; `smooth-movement flip` alone
 prints the current state. Turning it off restores every creature to its
 native orientation immediately and lets the plugin go back to idling rather
 than repainting tiles every frame for a feature that is switched off.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ smooth-movement
 disable smooth-movement
 ```
 
-The status command prints the plugin version and whether it is enabled.
+The status command prints the plugin version, whether it is enabled, the free
+camera state, and whether sprite flipping is on.
 
 ## Build
 
@@ -83,6 +84,23 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
 - Main creature sprites crossing fire snap instead of being replayed over an
   unsafe layer reconstruction.
 - UI and menus are rendered after interpolated world sprites.
+
+## Directional sprite flipping (on by default)
+
+Creature sprites mirror horizontally to face their direction of travel.
+Dwarf Fortress creature art natively faces west; a creature moving east is
+mirrored, a creature moving west is left alone. Facing is sticky: only
+horizontal movement changes it, so walking north or south, and standing
+still, keep the last horizontal facing. Worn clothing, armour, and weapons
+flip with the creature automatically because Dwarf Fortress composites them
+into a single tile sprite before the plugin sees it. Multi-tile creatures
+mirror as one composite, reflected about their anchor tile. Items, vehicles,
+and designations are never mirrored.
+
+Toggle it with `smooth-movement flip on|off`; `smooth-movement flip` alone
+prints the current state. Turning it off restores every creature to its
+native orientation immediately and lets the plugin go back to idling rather
+than repainting tiles every frame for a feature that is switched off.
 
 ## Free camera (optional, off by default)
 

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1166,6 +1166,83 @@ std::vector<render_proxyst> collect_proxies(
 				}
 			}
 		}
+
+	// A creature that has stopped still needs its mirrored sprite painted each
+	// frame; otherwise the engine repaints it in the art's native orientation
+	// and the two alternate between steps. A fragment's tile is its anchor
+	// minus the layer's centre offset, the inverse of the
+	// anchor == fragment + center_x relation the moving path matches on.
+	for(int32_t anchor_x=0;anchor_x<vp->dim_x;++anchor_x)
+		{
+		for(int32_t anchor_y=0;anchor_y<vp->dim_y;++anchor_y)
+			{
+			if(animation_manager.get_facing(vp,anchor_x,anchor_y)==
+				native_sprite_facing)continue;
+			for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
+				{
+				const viewport_visual_layer visual_layer=
+					visual_layer_at_draw_order(draw_order);
+				const visual_render_groupst group=
+					visual_render_group(visual_layer);
+				if(group!=visual_render_groupst::main&&
+					group!=visual_render_groupst::upper)continue;
+				const auto &descriptor=visual_layer_descriptor(visual_layer);
+				const int32_t x=anchor_x-descriptor.center_x;
+				const int32_t y=anchor_y-descriptor.center_y;
+				if(x<0||x>=vp->dim_x||y<0||y>=vp->dim_y)continue;
+				const size_t layer=static_cast<size_t>(visual_layer);
+				const int32_t texpos=layers[layer][x*vp->dim_y+y];
+				if(texpos==0)continue;
+				bool already_drawn=false;
+				for(const render_proxyst &existing:proxies)
+					if(existing.layer==visual_layer&&
+						existing.target_x==x&&existing.target_y==y)
+						already_drawn=true;
+				if(already_drawn)continue;
+
+				// source == target with progress 1.0 draws the sprite at its
+				// own tile, displaced only by mirror_shift and flipped.
+				render_proxyst proxy=
+					{
+					visual_layer,
+					float(x),
+					float(y),
+					x,
+					y,
+					texpos,
+					1.0f,
+					nullptr,
+					true,
+					2*descriptor.center_x,
+					{}
+					};
+				// The sprite lands on x+mirror_shift, so the closed interval
+				// between x and that tile is what has to be repaintable. The
+				// shift is negative, zero or positive depending on which side
+				// of the anchor the fragment sits, so order the ends first.
+				const int32_t coverage_first=std::min(x,x+proxy.mirror_shift);
+				const int32_t coverage_last=std::max(x,x+proxy.mirror_shift);
+				bool blocked=false;
+				for(int32_t coverage_x=coverage_first;
+					coverage_x<=coverage_last;++coverage_x)
+					{
+					if(!inside_clip(vp,coverage_x,y)||
+						(group==visual_render_groupst::main&&
+						has_fire(vp,coverage_x,y)))
+						{
+						blocked=true;
+						break;
+						}
+					proxy.coverage.emplace(coverage_x,y);
+					}
+				if(blocked)continue;
+
+				proxy.texture=cached_texture(renderer,texpos);
+				if(proxy.texture==nullptr)continue;
+				proxies.push_back(std::move(proxy));
+				}
+			}
+		}
 	return proxies;
 }
 
@@ -1292,7 +1369,8 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		}
 	if(glide)camera_was_offset=true;
 	if(!glide&&!animation_manager.requires_full_redraw()&&
-		!tile_transition_manager.active())
+		!tile_transition_manager.active()&&
+		!animation_manager.has_mirrored_facing(vp))
 		return;
 
 	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1091,11 +1091,11 @@ std::vector<render_proxyst> collect_proxies(
 						vp,
 						x+mirror_descriptor.center_x,
 						y+mirror_descriptor.center_y)!=native_sprite_facing;
-				// Reflecting a fragment about its anchor moves it by twice its
-				// offset to that anchor. The anchor itself has center_x 0 and
-				// so only flips in place.
+				// The anchor's own layer has center_x 0, so it flips in place.
 				const int32_t mirror_shift=
-					mirrored?2*mirror_descriptor.center_x:0;
+					mirrored?
+					mirrored_tile_x(x,x+mirror_descriptor.center_x)-x:
+					0;
 				render_proxyst proxy=
 					{
 					static_cast<viewport_visual_layer>(layer),
@@ -1213,7 +1213,7 @@ std::vector<render_proxyst> collect_proxies(
 						1.0f,
 						nullptr,
 						true,
-						2*descriptor.center_x,
+						mirrored_tile_x(x,anchor_x)-x,
 						{}
 						};
 					// The sprite lands on x+mirror_shift, so that interval must be repaintable.

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -44,14 +44,8 @@ REQUIRE_GLOBAL(window_z);
 namespace {
 
 constexpr const char *plugin_version="0.3.0";
-#ifdef WIN32
-constexpr const char *sdl_library="SDL2.dll";
-#else
-constexpr const char *sdl_library="libSDL2-2.0.so.0";
-#endif
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
-DFLibrary *sdl_handle=nullptr;
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
 decltype(&SDL_RenderCopyExF) render_copy_ex_f=nullptr;
 decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
@@ -76,7 +70,7 @@ int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
 bool construction_transitions_enabled=false;
-bool flip_enabled=true;   // ON by default: creature sprites mirror to face travel direction.
+bool flip_enabled=false;
 
 // --- free camera -------------------------------------------------------------------------------
 // The camera is visually unbound from the tile grid. Two layered offsets:
@@ -1469,8 +1463,6 @@ void renderer_hook::interpose_fn_update_all()
 
 void clear_sdl_bindings()
 {
-	if(sdl_handle!=nullptr)ClosePlugin(sdl_handle);
-	sdl_handle=nullptr;
 	render_copy_f=nullptr;
 	render_copy_ex_f=nullptr;
 	render_fill_rect=nullptr;
@@ -1486,12 +1478,7 @@ void clear_sdl_bindings()
 bool load_sdl(color_ostream &out)
 {
 	clear_sdl_bindings();
-	sdl_handle=OpenPlugin(sdl_library);
-	if(sdl_handle==nullptr)
-		{
-		out.printerr("smooth-movement: could not load SDL2\n");
-		return false;
-		}
+	DFLibrary *sdl_handle=DFSDL::obtain_library_handle();
 	#define bind(name,target) \
 		target=reinterpret_cast<decltype(target)>(LookupPlugin(sdl_handle,#name)); \
 		if(target==nullptr) { \
@@ -1532,7 +1519,7 @@ void reset_state()
 	camera_has_prev=false;
 	camera_was_offset=false;
 	construction_transitions_enabled=false;
-	flip_enabled=true;
+	flip_enabled=false;
 }
 
 command_result status_command(

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1076,6 +1076,25 @@ std::vector<render_proxyst> collect_proxies(
 						}
 					}
 
+				// Items, vehicles and designations keep their vanilla orientation.
+				const auto &mirror_descriptor=
+					visual_layer_descriptor(visual_layer);
+				const visual_render_groupst group=
+					visual_render_group(visual_layer);
+				const bool mirror_eligible=
+					group==visual_render_groupst::main||
+					group==visual_render_groupst::upper;
+				// Facing is read from the anchor tile so every fragment of one creature agrees.
+				const bool mirrored=mirror_eligible&&
+					animation_manager.get_facing(
+						vp,
+						x+mirror_descriptor.center_x,
+						y+mirror_descriptor.center_y)!=native_sprite_facing;
+				// Reflecting a fragment about its anchor moves it by twice its
+				// offset to that anchor. The anchor itself has center_x 0 and
+				// so only flips in place.
+				const int32_t mirror_shift=
+					mirrored?2*mirror_descriptor.center_x:0;
 				render_proxyst proxy=
 					{
 					static_cast<viewport_visual_layer>(layer),
@@ -1086,6 +1105,8 @@ std::vector<render_proxyst> collect_proxies(
 					texpos,
 					movement.progress,
 					nullptr,
+					mirrored,
+					mirror_shift,
 					{}
 					};
 				bool blocked=false;
@@ -1115,6 +1136,29 @@ std::vector<render_proxyst> collect_proxies(
 					if(blocked)break;
 					}
 				if(blocked)continue;
+				if(proxy.mirror_shift!=0)
+					{
+					std::set<std::pair<int32_t,int32_t>> mirrored_coverage;
+					for(const auto &tile:proxy.coverage)
+						mirrored_coverage.emplace(
+							tile.first+proxy.mirror_shift,tile.second);
+					for(const auto &tile:mirrored_coverage)
+						{
+						if(!inside_clip(vp,tile.first,tile.second))
+							{
+							blocked=true;
+							break;
+							}
+						if(visual_render_group(proxy.layer)==visual_render_groupst::main&&
+							has_fire(vp,tile.first,tile.second))
+							{
+							blocked=true;
+							break;
+							}
+						proxy.coverage.insert(tile);
+						}
+					if(blocked)continue;
+					}
 
 				proxy.texture=cached_texture(renderer,texpos);
 				if(proxy.texture==nullptr)continue;

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -76,6 +76,7 @@ int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
 bool construction_transitions_enabled=false;
+bool flip_enabled=true;   // ON by default: creature sprites mirror to face travel direction.
 
 // --- free camera -------------------------------------------------------------------------------
 // The camera is visually unbound from the tile grid. Two layered offsets:
@@ -1081,9 +1082,9 @@ std::vector<render_proxyst> collect_proxies(
 					visual_layer_descriptor(visual_layer);
 				const visual_render_groupst group=
 					visual_render_group(visual_layer);
-				const bool mirror_eligible=
-					group==visual_render_groupst::main||
-					group==visual_render_groupst::upper;
+				const bool mirror_eligible=flip_enabled&&
+					(group==visual_render_groupst::main||
+					group==visual_render_groupst::upper);
 				// Facing is read from the anchor tile so every fragment of one creature agrees.
 				const bool mirrored=mirror_eligible&&
 					animation_manager.get_facing(
@@ -1167,79 +1168,77 @@ std::vector<render_proxyst> collect_proxies(
 			}
 		}
 
-	// A creature that has stopped still needs its mirrored sprite painted each
-	// frame; otherwise the engine repaints it in the art's native orientation
-	// and the two alternate between steps. A fragment's tile is its anchor
-	// minus the layer's centre offset, the inverse of the
-	// anchor == fragment + center_x relation the moving path matches on.
-	for(int32_t anchor_x=0;anchor_x<vp->dim_x;++anchor_x)
+	// A creature that has stopped still needs its mirrored sprite painted each frame.
+	// Otherwise the engine repaints it natively and the two orientations alternate between steps.
+	// A fragment's tile is its anchor minus the layer's centre offset, inverting the moving path.
+	if(flip_enabled)
 		{
-		for(int32_t anchor_y=0;anchor_y<vp->dim_y;++anchor_y)
+		for(int32_t anchor_x=0;anchor_x<vp->dim_x;++anchor_x)
 			{
-			if(animation_manager.get_facing(vp,anchor_x,anchor_y)==
-				native_sprite_facing)continue;
-			for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
+			for(int32_t anchor_y=0;anchor_y<vp->dim_y;++anchor_y)
 				{
-				const viewport_visual_layer visual_layer=
-					visual_layer_at_draw_order(draw_order);
-				const visual_render_groupst group=
-					visual_render_group(visual_layer);
-				if(group!=visual_render_groupst::main&&
-					group!=visual_render_groupst::upper)continue;
-				const auto &descriptor=visual_layer_descriptor(visual_layer);
-				const int32_t x=anchor_x-descriptor.center_x;
-				const int32_t y=anchor_y-descriptor.center_y;
-				if(x<0||x>=vp->dim_x||y<0||y>=vp->dim_y)continue;
-				const size_t layer=static_cast<size_t>(visual_layer);
-				const int32_t texpos=layers[layer][x*vp->dim_y+y];
-				if(texpos==0)continue;
-				bool already_drawn=false;
-				for(const render_proxyst &existing:proxies)
-					if(existing.layer==visual_layer&&
-						existing.target_x==x&&existing.target_y==y)
-						already_drawn=true;
-				if(already_drawn)continue;
+				if(animation_manager.get_facing(vp,anchor_x,anchor_y)==
+					native_sprite_facing)continue;
+				for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
+					{
+					const viewport_visual_layer visual_layer=
+						visual_layer_at_draw_order(draw_order);
+					const visual_render_groupst group=
+						visual_render_group(visual_layer);
+					if(group!=visual_render_groupst::main&&
+						group!=visual_render_groupst::upper)continue;
+					const auto &descriptor=visual_layer_descriptor(visual_layer);
+					const int32_t x=anchor_x-descriptor.center_x;
+					const int32_t y=anchor_y-descriptor.center_y;
+					if(x<0||x>=vp->dim_x||y<0||y>=vp->dim_y)continue;
+					const size_t layer=static_cast<size_t>(visual_layer);
+					const int32_t texpos=layers[layer][x*vp->dim_y+y];
+					if(texpos==0)continue;
+					bool already_drawn=false;
+					for(const render_proxyst &existing:proxies)
+						if(existing.layer==visual_layer&&
+							existing.target_x==x&&existing.target_y==y)
+							already_drawn=true;
+					if(already_drawn)continue;
 
-				// source == target with progress 1.0 draws the sprite at its
-				// own tile, displaced only by mirror_shift and flipped.
-				render_proxyst proxy=
-					{
-					visual_layer,
-					float(x),
-					float(y),
-					x,
-					y,
-					texpos,
-					1.0f,
-					nullptr,
-					true,
-					2*descriptor.center_x,
-					{}
-					};
-				// The sprite lands on x+mirror_shift, so the closed interval
-				// between x and that tile is what has to be repaintable. The
-				// shift is negative, zero or positive depending on which side
-				// of the anchor the fragment sits, so order the ends first.
-				const int32_t coverage_first=std::min(x,x+proxy.mirror_shift);
-				const int32_t coverage_last=std::max(x,x+proxy.mirror_shift);
-				bool blocked=false;
-				for(int32_t coverage_x=coverage_first;
-					coverage_x<=coverage_last;++coverage_x)
-					{
-					if(!inside_clip(vp,coverage_x,y)||
-						(group==visual_render_groupst::main&&
-						has_fire(vp,coverage_x,y)))
+					// source == target at progress 1.0 draws in place, moved only by mirror_shift.
+					render_proxyst proxy=
 						{
-						blocked=true;
-						break;
+						visual_layer,
+						float(x),
+						float(y),
+						x,
+						y,
+						texpos,
+						1.0f,
+						nullptr,
+						true,
+						2*descriptor.center_x,
+						{}
+						};
+					// The sprite lands on x+mirror_shift, so that interval must be repaintable.
+					// The shift has either sign, so order the interval ends first.
+					const int32_t coverage_first=std::min(x,x+proxy.mirror_shift);
+					const int32_t coverage_last=std::max(x,x+proxy.mirror_shift);
+					bool blocked=false;
+					for(int32_t coverage_x=coverage_first;
+						coverage_x<=coverage_last;++coverage_x)
+						{
+						if(!inside_clip(vp,coverage_x,y)||
+							(group==visual_render_groupst::main&&
+							has_fire(vp,coverage_x,y)))
+							{
+							blocked=true;
+							break;
+							}
+						proxy.coverage.emplace(coverage_x,y);
 						}
-					proxy.coverage.emplace(coverage_x,y);
-					}
-				if(blocked)continue;
+					if(blocked)continue;
 
-				proxy.texture=cached_texture(renderer,texpos);
-				if(proxy.texture==nullptr)continue;
-				proxies.push_back(std::move(proxy));
+					proxy.texture=cached_texture(renderer,texpos);
+					if(proxy.texture==nullptr)continue;
+					proxies.push_back(std::move(proxy));
+					}
 				}
 			}
 		}
@@ -1370,7 +1369,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	if(glide)camera_was_offset=true;
 	if(!glide&&!animation_manager.requires_full_redraw()&&
 		!tile_transition_manager.active()&&
-		!animation_manager.has_mirrored_facing(vp))
+		(!flip_enabled||!animation_manager.has_mirrored_facing(vp)))
 		return;
 
 	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);
@@ -1533,6 +1532,7 @@ void reset_state()
 	camera_has_prev=false;
 	camera_was_offset=false;
 	construction_transitions_enabled=false;
+	flip_enabled=true;
 }
 
 command_result status_command(
@@ -1549,6 +1549,8 @@ command_result status_command(
 			camera_enabled?"on":"off",-rest_x,-rest_y);
 		out.print("construction transitions: {}\n",
 			construction_transitions_enabled?"on":"off");
+		out.print("sprite flipping: {}\n",
+			flip_enabled?"on":"off");
 		return CR_OK;
 		}
 	if(parameters[0]=="construction")
@@ -1621,6 +1623,34 @@ command_result status_command(
 			}
 		return CR_WRONG_USAGE;
 		}
+	if(parameters[0]=="flip")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("sprite flipping: {}\n",
+				flip_enabled?"on":"off");
+			return CR_OK;
+			}
+		// A toggle changes the screen without changing anything DF knows, so DF will not repaint.
+		// OFF matters most: the render path stops touching tiles it painted every frame.
+		// The last mirrored frame would persist.
+		// Same flush plugin_enable(false) uses.
+		if(parameters.size()==2&&parameters[1]=="on")
+			{
+			flip_enabled=true;
+			if(gps!=nullptr)++gps->force_full_display_count;
+			out.print("smooth-movement: sprite flipping enabled\n");
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="off")
+			{
+			flip_enabled=false;
+			if(gps!=nullptr)++gps->force_full_display_count;
+			out.print("smooth-movement: sprite flipping disabled\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
+		}
 	return CR_WRONG_USAGE;
 }
 
@@ -1631,7 +1661,8 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 {
 	commands.emplace_back(
 		"smooth-movement",
-		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>.",
+		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
+		"sprite flipping: flip on|off.",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -53,6 +53,7 @@ constexpr const char *sdl_library="libSDL2-2.0.so.0";
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 DFLibrary *sdl_handle=nullptr;
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
+decltype(&SDL_RenderCopyExF) render_copy_ex_f=nullptr;
 decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
 decltype(&SDL_RenderSetClipRect) render_set_clip_rect=nullptr;
 decltype(&SDL_GetRenderDrawColor) get_render_draw_color=nullptr;
@@ -740,6 +741,8 @@ struct render_proxyst
 	int32_t texpos;
 	float progress;
 	SDL_Texture *texture;
+	bool mirrored=false;
+	int32_t mirror_shift=0;
 	std::set<std::pair<int32_t,int32_t>> coverage;
 };
 
@@ -929,11 +932,30 @@ SDL_Texture *cached_tile_texture(
 	return texture!=nullptr?texture:cached_texture(renderer,texpos);
 }
 
+// The render_copy_ex_f null check is defensive only, not a graceful-degradation path.
+// `bind` aborts load_sdl on any missing symbol and plugin_enable then refuses the render hook.
+void render_copy_maybe_mirrored(
+	SDL_Renderer *renderer,
+	SDL_Texture *texture,
+	const SDL_FRect &destination,
+	bool mirrored)
+{
+	if(mirrored&&render_copy_ex_f!=nullptr)
+		{
+		render_copy_ex_f(
+			renderer,texture,nullptr,&destination,
+			0.0,nullptr,SDL_FLIP_HORIZONTAL);
+		return;
+		}
+	render_copy_f(renderer,texture,nullptr,&destination);
+}
+
 void draw_texture_with_alpha(
 	SDL_Renderer *renderer,
 	SDL_Texture *texture,
 	const SDL_FRect &destination,
-	float opacity)
+	float opacity,
+	bool mirrored)
 {
 	if(opacity<=0.0f)return;
 	Uint8 saved_alpha=255;
@@ -941,12 +963,12 @@ void draw_texture_with_alpha(
 	if(get_texture_alpha_mod(texture,&saved_alpha)!=0||
 		get_texture_blend_mode(texture,&saved_blend)!=0)
 		{
-		render_copy_f(renderer,texture,nullptr,&destination);
+		render_copy_maybe_mirrored(renderer,texture,destination,mirrored);
 		return;
 		}
 	set_texture_blend_mode(texture,SDL_BLENDMODE_BLEND);
 	set_texture_alpha_mod(texture,Uint8(std::lround(saved_alpha*opacity)));
-	render_copy_f(renderer,texture,nullptr,&destination);
+	render_copy_maybe_mirrored(renderer,texture,destination,mirrored);
 	set_texture_alpha_mod(texture,saved_alpha);
 	set_texture_blend_mode(texture,saved_blend);
 }
@@ -959,18 +981,19 @@ void draw_proxy(df::renderer_2d_base *renderer,const render_proxyst &proxy)
 	const float tile_size=float(zoom==128?32:std::max(1,zoom*32/128));
 	const float source_x=target_x+(proxy.source_x-proxy.target_x)*tile_size;
 	const float source_y=target_y+(proxy.source_y-proxy.target_y)*tile_size;
+	const float mirror_offset=float(proxy.mirror_shift)*tile_size;
 	const SDL_FRect destination=
 		{
-		source_x+(target_x-source_x)*proxy.progress,
+		source_x+(target_x-source_x)*proxy.progress+mirror_offset,
 		source_y+(target_y-source_y)*proxy.progress,
 		tile_size,
 		tile_size
 		};
-	render_copy_f(
+	render_copy_maybe_mirrored(
 		static_cast<SDL_Renderer *>(renderer->sdl_renderer),
 		proxy.texture,
-		nullptr,
-		&destination);
+		destination,
+		proxy.mirrored);
 }
 
 std::vector<render_proxyst> collect_proxies(
@@ -1165,9 +1188,9 @@ void draw_tile_transitions(
 			continue;
 			}
 		if(previous!=nullptr)
-			draw_texture_with_alpha(sdl_renderer,previous,destination,1.0f-progress);
+			draw_texture_with_alpha(sdl_renderer,previous,destination,1.0f-progress,false);
 		if(current!=nullptr)
-			draw_texture_with_alpha(sdl_renderer,current,destination,progress);
+			draw_texture_with_alpha(sdl_renderer,current,destination,progress,false);
 		}
 }
 
@@ -1328,6 +1351,7 @@ void clear_sdl_bindings()
 	if(sdl_handle!=nullptr)ClosePlugin(sdl_handle);
 	sdl_handle=nullptr;
 	render_copy_f=nullptr;
+	render_copy_ex_f=nullptr;
 	render_fill_rect=nullptr;
 	render_set_clip_rect=nullptr;
 	get_render_draw_color=nullptr;
@@ -1355,6 +1379,7 @@ bool load_sdl(color_ostream &out)
 			return false; \
 		}
 	bind(SDL_RenderCopyF,render_copy_f);
+	bind(SDL_RenderCopyExF,render_copy_ex_f);
 	bind(SDL_RenderFillRect,render_fill_rect);
 	bind(SDL_RenderSetClipRect,render_set_clip_rect);
 	bind(SDL_GetRenderDrawColor,get_render_draw_color);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -134,6 +134,32 @@ int main()
 	assert(manager.get_facing(viewport,2,2)==visual_facingst::east);
 	}
 
+	// The mirrored flag gates the render path's early return.
+	// It must rise only for a genuinely mirrored creature and fall when that tile empties.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	assert(!manager.has_mirrored_facing(viewport));
+	// Moving west matches the art, so nothing is mirrored yet.
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
+	assert(!manager.has_mirrored_facing(viewport));
+	// Moving east faces away from the art and raises the flag.
+	set_layer(input,viewport_visual_layer::center,before,west_after);
+	run_frame(manager,input,1032);
+	assert(manager.get_facing(viewport,2,2)==visual_facingst::east);
+	assert(manager.has_mirrored_facing(viewport));
+	// The creature leaves: the tile clears and so does the flag.
+	set_layer(input,viewport_visual_layer::center,empty,before);
+	run_frame(manager,input,1048);
+	assert(manager.get_facing(viewport,2,2)==native_sprite_facing);
+	assert(!manager.has_mirrored_facing(viewport));
+	assert(!manager.has_mirrored_facing(nullptr));
+	}
+
 	// Pure vertical movement carries the existing facing to the new tile.
 	{
 	visual_animation_managerst manager;

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -84,7 +84,10 @@ int main()
 	// Facing rule: only a horizontal component changes facing.
 	assert(facing_after_move(1,visual_facingst::west)==visual_facingst::east);
 	assert(facing_after_move(-1,visual_facingst::east)==visual_facingst::west);
-	// Diagonals use their horizontal component.
+	// dy is not an input, so a diagonal is only ever the sign of dx.
+	// The four real diagonals run end to end through the manager further down.
+	assert(facing_after_move(1,visual_facingst::east)==visual_facingst::east);
+	assert(facing_after_move(-1,visual_facingst::west)==visual_facingst::west);
 	// Pure vertical and idle carry the previous facing (sticky).
 	assert(facing_after_move(0,visual_facingst::west)==visual_facingst::west);
 	assert(facing_after_move(0,visual_facingst::east)==visual_facingst::east);
@@ -92,7 +95,11 @@ int main()
 	assert(mirrored_tile_x(5,5)==5);   // anchor reflects to itself
 	assert(mirrored_tile_x(6,5)==4);   // right spill -> left
 	assert(mirrored_tile_x(4,5)==6);   // left spill -> right
-	assert(mirrored_tile_x(8,5)==2);   // width 6 needs no special case
+	// The formula is a general reflection, so it holds for offsets no layer can express.
+	assert(mirrored_tile_x(8,5)==2);
+	// center_x is only ever -1, 0 or +1, so the real mirror shift is only ever -2, 0 or +2.
+	for(const auto &descriptor:visual_layer_descriptors)
+		assert(descriptor.center_x>=-1&&descriptor.center_x<=1);
 	// Reflection is self-inverse.
 	assert(mirrored_tile_x(mirrored_tile_x(6,5),5)==6);
 	assert(mirrored_tile_x(mirrored_tile_x(8,5),5)==8);
@@ -186,6 +193,54 @@ int main()
 	assert(manager.get_facing(viewport,dim,0)==native_sprite_facing);
 	assert(manager.get_facing(nullptr,0,0)==native_sprite_facing);
 	}
+	}
+
+	// All four diagonals through the manager, so every step carries a real dy as well as a dx.
+	// The chain alternates direction, so no assertion can pass by inheriting the previous facing.
+	{
+	constexpr int32_t diag_dim=5;
+	int32_t diag_empty[diag_dim*diag_dim]={};
+	int32_t start[diag_dim*diag_dim]={};
+	int32_t north_east[diag_dim*diag_dim]={};
+	int32_t south_west[diag_dim*diag_dim]={};
+	int32_t south_east[diag_dim*diag_dim]={};
+	int32_t north_west[diag_dim*diag_dim]={};
+	const int diag_token=0;
+	const void *diag_viewport=&diag_token;
+
+	start[2*diag_dim+2]=77;        // (2,2)
+	north_east[3*diag_dim+1]=77;   // (2,2) -> (3,1): dx +1, dy -1
+	south_west[2*diag_dim+2]=77;   // (3,1) -> (2,2): dx -1, dy +1
+	south_east[3*diag_dim+3]=77;   // (2,2) -> (3,3): dx +1, dy +1
+	north_west[2*diag_dim+2]=77;   // (3,3) -> (2,2): dx -1, dy -1
+
+	visual_animation_managerst diagonal;
+	auto input=make_input(diag_viewport,diag_dim,diag_empty);
+	set_layer(input,viewport_visual_layer::center,start,diag_empty);
+	run_frame(diagonal,input,1000);
+	assert(diagonal.get_facing(diag_viewport,2,2)==native_sprite_facing);
+
+	set_layer(input,viewport_visual_layer::center,north_east,start);
+	run_frame(diagonal,input,1016);
+	assert(diagonal.get_facing(diag_viewport,3,1)==visual_facingst::east);
+
+	// West is the grid default, so the westward legs also assert a movement was registered.
+	// Otherwise an untracked step leaving the tile at its default would pass.
+	set_layer(input,viewport_visual_layer::center,south_west,north_east);
+	run_frame(diagonal,input,1032);
+	assert(diagonal.get_movement(
+		diag_viewport,viewport_visual_layer::center,2,2).active);
+	assert(diagonal.get_facing(diag_viewport,2,2)==visual_facingst::west);
+
+	set_layer(input,viewport_visual_layer::center,south_east,south_west);
+	run_frame(diagonal,input,1048);
+	assert(diagonal.get_facing(diag_viewport,3,3)==visual_facingst::east);
+
+	set_layer(input,viewport_visual_layer::center,north_west,south_east);
+	run_frame(diagonal,input,1064);
+	assert(diagonal.get_movement(
+		diag_viewport,viewport_visual_layer::center,2,2).active);
+	assert(diagonal.get_facing(diag_viewport,2,2)==visual_facingst::west);
 	}
 
 	// Regression: A and B move in the same frame, chained -- A's target tile is B's source tile.

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -119,9 +119,8 @@ int main()
 	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
 	}
 
-	// Moving east sets east facing. The target's prior facing is made
-	// genuinely west first (not the grid's default east), so this only
-	// passes if the east branch of facing_after_move is actually taken.
+	// Moving east sets east facing.
+	// East is neither the grid default nor the source facing, so the assertion is not vacuous.
 	{
 	visual_animation_managerst manager;
 	auto input=make_input(viewport,dim,empty);
@@ -151,23 +150,21 @@ int main()
 	assert(manager.get_facing(viewport,1,1)==visual_facingst::west);
 	}
 
-	// Out-of-range and unknown viewports default to east.
+	// Out-of-range and unknown viewports fall back to the native facing.
 	{
 	visual_animation_managerst manager;
 	auto input=make_input(viewport,dim,empty);
 	set_layer(input,viewport_visual_layer::center,before,empty);
 	run_frame(manager,input,1000);
-	assert(manager.get_facing(viewport,-1,0)==visual_facingst::east);
-	assert(manager.get_facing(viewport,dim,0)==visual_facingst::east);
-	assert(manager.get_facing(nullptr,0,0)==visual_facingst::east);
+	assert(manager.get_facing(viewport,-1,0)==native_sprite_facing);
+	assert(manager.get_facing(viewport,dim,0)==native_sprite_facing);
+	assert(manager.get_facing(nullptr,0,0)==native_sprite_facing);
 	}
 	}
 
-	// Regression: two creatures marching in the same column in a single
-	// frame is exactly the case shared_movement_delta exists to detect,
-	// and it is a chain -- A's target tile is B's source tile. A's write
-	// must not corrupt B's read of its own pre-frame facing. A picks up
-	// a genuinely different (west) facing first so a swap is observable.
+	// Regression: A and B move in the same frame, chained -- A's target tile is B's source tile.
+	// A's write must not corrupt B's read of its own pre-frame facing.
+	// A is sent east first, so its facing differs from the default B carries and a swap shows.
 	{
 	constexpr int32_t chase_dim=5;
 	int32_t chase_empty[chase_dim*chase_dim]={};
@@ -177,12 +174,9 @@ int main()
 	const int chase_token=0;
 	const void *chase_viewport=&chase_token;
 
-	// A starts off-column and steps west into the column, picking up a
-	// west facing. B sits stationary in the column, keeping its default
-	// (east) facing.
-	frame_a[3*chase_dim+1]=77;   // A at (3,1)
-	frame_a[2*chase_dim+2]=88;   // B at (2,2), stationary
-	frame_b[2*chase_dim+1]=77;   // A steps west: (3,1) -> (2,1)
+	frame_a[1*chase_dim+1]=77;   // A at (1,1)
+	frame_a[2*chase_dim+2]=88;   // B at (2,2), stationary, keeps the default facing
+	frame_b[2*chase_dim+1]=77;   // A steps east: (1,1) -> (2,1), picks up an east facing
 	frame_b[2*chase_dim+2]=88;   // B unchanged
 
 	// Both step south in the same frame: shared_movement_delta needs two tiles on the same delta.
@@ -195,17 +189,14 @@ int main()
 	run_frame(manager,input,1000);
 	set_layer(input,viewport_visual_layer::center,frame_b,frame_a);
 	run_frame(manager,input,1016);
-	assert(manager.get_facing(chase_viewport,2,1)==visual_facingst::west);
-	assert(manager.get_facing(chase_viewport,2,2)==visual_facingst::east);
+	assert(manager.get_facing(chase_viewport,2,1)==visual_facingst::east);
+	assert(manager.get_facing(chase_viewport,2,2)==native_sprite_facing);
 
 	set_layer(input,viewport_visual_layer::center,frame_c,frame_b);
 	run_frame(manager,input,1032);
-	// A carries its own (west) facing forward.
-	assert(manager.get_facing(chase_viewport,2,2)==visual_facingst::west);
-	// B carries its own (east) facing forward -- not A's, even though A's
-	// write into (2,2) happens earlier in the same raster pass that B's
-	// movement reads (2,2) as its source.
-	assert(manager.get_facing(chase_viewport,2,3)==visual_facingst::east);
+	assert(manager.get_facing(chase_viewport,2,2)==visual_facingst::east);
+	// B carries its own default forward, not A's, though A wrote (2,2) earlier in the same pass.
+	assert(manager.get_facing(chase_viewport,2,3)==native_sprite_facing);
 	}
 
 	// Regression: a vacated source tile is reoccupied the same frame by an UNTRACKED creature.
@@ -220,12 +211,11 @@ int main()
 	const int gap_token=0;
 	const void *gap_viewport=&gap_token;
 
-	// D at (3,1); E is a stationary companion at (2,2) so that D's later
-	// southward departure from (2,1) shares a delta with E's own move and
-	// shared_movement_delta engages (it needs two tiles on the same delta).
-	frame_a[3*gap_dim+1]=77;   // D
-	frame_a[2*gap_dim+2]=88;   // E, stationary companion
-	frame_b[2*gap_dim+1]=77;   // D steps west: (3,1) -> (2,1), picks up west facing
+	// E is a companion so that D's later departure shares a delta with E's own move.
+	// shared_movement_delta engages only once two tiles move on the same delta.
+	frame_a[1*gap_dim+1]=77;   // D at (1,1)
+	frame_a[2*gap_dim+2]=88;   // E at (2,2), stationary companion
+	frame_b[2*gap_dim+1]=77;   // D steps east: (1,1) -> (2,1), facing differs from the default
 	frame_b[2*gap_dim+2]=88;   // E unchanged
 
 	// D and E both step south, chained, and F appears at D's just-vacated tile the same frame.
@@ -241,17 +231,16 @@ int main()
 	run_frame(manager,input,1000);
 	set_layer(input,viewport_visual_layer::center,frame_b,frame_a);
 	run_frame(manager,input,1016);
-	assert(manager.get_facing(gap_viewport,2,1)==visual_facingst::west);
+	assert(manager.get_facing(gap_viewport,2,1)==visual_facingst::east);
 
 	set_layer(input,viewport_visual_layer::center,frame_c,frame_b);
 	run_frame(manager,input,1032);
 	assert(!manager.get_movement(
 		gap_viewport,viewport_visual_layer::center,2,1).active);
-	// F must not inherit D's stale west facing -- the tile falls back to
-	// the default (east) even though it is occupied, not empty.
-	assert(manager.get_facing(gap_viewport,2,1)==visual_facingst::east);
-	assert(manager.get_facing(gap_viewport,2,2)==visual_facingst::west);
-	assert(manager.get_facing(gap_viewport,2,3)==visual_facingst::east);
+	// F must not inherit D's stale east facing, though the tile is occupied rather than empty.
+	assert(manager.get_facing(gap_viewport,2,1)==native_sprite_facing);
+	assert(manager.get_facing(gap_viewport,2,2)==visual_facingst::east);
+	assert(manager.get_facing(gap_viewport,2,3)==native_sprite_facing);
 	}
 
 	assert(animation_progress(100,0,100)==1.0f);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -80,6 +80,23 @@ int main()
 	assert(dug.previous_texpos==10&&dug.current_texpos==0);
 	assert(select_tile_transition(10,10,20,20).layer==
 		tile_transition_layer::none);
+
+	// Facing rule: only a horizontal component changes facing.
+	assert(facing_after_move(1,visual_facingst::west)==visual_facingst::east);
+	assert(facing_after_move(-1,visual_facingst::east)==visual_facingst::west);
+	// Diagonals use their horizontal component.
+	// Pure vertical and idle carry the previous facing (sticky).
+	assert(facing_after_move(0,visual_facingst::west)==visual_facingst::west);
+	assert(facing_after_move(0,visual_facingst::east)==visual_facingst::east);
+
+	assert(mirrored_tile_x(5,5)==5);   // anchor reflects to itself
+	assert(mirrored_tile_x(6,5)==4);   // right spill -> left
+	assert(mirrored_tile_x(4,5)==6);   // left spill -> right
+	assert(mirrored_tile_x(8,5)==2);   // width 6 needs no special case
+	// Reflection is self-inverse.
+	assert(mirrored_tile_x(mirrored_tile_x(6,5),5)==6);
+	assert(mirrored_tile_x(mirrored_tile_x(8,5),5)==8);
+
 	assert(animation_progress(100,0,100)==1.0f);
 	assert(inherited_visual_source_tile(0,0,1)==-1);
 	assert(inherited_visual_source_tile(2,0,1)==1);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -97,6 +97,163 @@ int main()
 	assert(mirrored_tile_x(mirrored_tile_x(6,5),5)==6);
 	assert(mirrored_tile_x(mirrored_tile_x(8,5),5)==8);
 
+	{
+	constexpr int32_t dim=4;
+	int32_t empty[dim*dim]={};
+	int32_t before[dim*dim]={};
+	int32_t west_after[dim*dim]={};
+	const int viewport_token=0;
+	const void *viewport=&viewport_token;
+
+	before[2*dim+2]=77;
+	west_after[1*dim+2]=77;   // moved west: x 2 -> 1
+
+	// Moving west sets west facing on the target tile.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
+	}
+
+	// Moving east sets east facing. The target's prior facing is made
+	// genuinely west first (not the grid's default east), so this only
+	// passes if the east branch of facing_after_move is actually taken.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
+	set_layer(input,viewport_visual_layer::center,before,west_after);
+	run_frame(manager,input,1032);
+	assert(manager.get_facing(viewport,2,2)==visual_facingst::east);
+	}
+
+	// Pure vertical movement carries the existing facing to the new tile.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
+	int32_t up[dim*dim]={};
+	up[1*dim+1]=77;   // north: (1,2) -> (1,1), no horizontal component
+	set_layer(input,viewport_visual_layer::center,up,west_after);
+	run_frame(manager,input,1032);
+	assert(manager.get_facing(viewport,1,1)==visual_facingst::west);
+	}
+
+	// Out-of-range and unknown viewports default to east.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	assert(manager.get_facing(viewport,-1,0)==visual_facingst::east);
+	assert(manager.get_facing(viewport,dim,0)==visual_facingst::east);
+	assert(manager.get_facing(nullptr,0,0)==visual_facingst::east);
+	}
+	}
+
+	// Regression: two creatures marching in the same column in a single
+	// frame is exactly the case shared_movement_delta exists to detect,
+	// and it is a chain -- A's target tile is B's source tile. A's write
+	// must not corrupt B's read of its own pre-frame facing. A picks up
+	// a genuinely different (west) facing first so a swap is observable.
+	{
+	constexpr int32_t chase_dim=5;
+	int32_t chase_empty[chase_dim*chase_dim]={};
+	int32_t frame_a[chase_dim*chase_dim]={};
+	int32_t frame_b[chase_dim*chase_dim]={};
+	int32_t frame_c[chase_dim*chase_dim]={};
+	const int chase_token=0;
+	const void *chase_viewport=&chase_token;
+
+	// A starts off-column and steps west into the column, picking up a
+	// west facing. B sits stationary in the column, keeping its default
+	// (east) facing.
+	frame_a[3*chase_dim+1]=77;   // A at (3,1)
+	frame_a[2*chase_dim+2]=88;   // B at (2,2), stationary
+	frame_b[2*chase_dim+1]=77;   // A steps west: (3,1) -> (2,1)
+	frame_b[2*chase_dim+2]=88;   // B unchanged
+
+	// Both step south in the same frame: shared_movement_delta needs two tiles on the same delta.
+	frame_c[2*chase_dim+2]=77;   // A: (2,1) -> (2,2)
+	frame_c[2*chase_dim+3]=88;   // B: (2,2) -> (2,3)
+
+	visual_animation_managerst manager;
+	auto input=make_input(chase_viewport,chase_dim,chase_empty);
+	set_layer(input,viewport_visual_layer::center,frame_a,chase_empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,frame_b,frame_a);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(chase_viewport,2,1)==visual_facingst::west);
+	assert(manager.get_facing(chase_viewport,2,2)==visual_facingst::east);
+
+	set_layer(input,viewport_visual_layer::center,frame_c,frame_b);
+	run_frame(manager,input,1032);
+	// A carries its own (west) facing forward.
+	assert(manager.get_facing(chase_viewport,2,2)==visual_facingst::west);
+	// B carries its own (east) facing forward -- not A's, even though A's
+	// write into (2,2) happens earlier in the same raster pass that B's
+	// movement reads (2,2) as its source.
+	assert(manager.get_facing(chase_viewport,2,3)==visual_facingst::east);
+	}
+
+	// Regression: a vacated source tile is reoccupied the same frame by an UNTRACKED creature.
+	// Nothing targets that tile, so no target write clears it, and it is not empty either.
+	// Only an explicit, order-independent source clear restores the default there.
+	{
+	constexpr int32_t gap_dim=5;
+	int32_t gap_empty[gap_dim*gap_dim]={};
+	int32_t frame_a[gap_dim*gap_dim]={};
+	int32_t frame_b[gap_dim*gap_dim]={};
+	int32_t frame_c[gap_dim*gap_dim]={};
+	const int gap_token=0;
+	const void *gap_viewport=&gap_token;
+
+	// D at (3,1); E is a stationary companion at (2,2) so that D's later
+	// southward departure from (2,1) shares a delta with E's own move and
+	// shared_movement_delta engages (it needs two tiles on the same delta).
+	frame_a[3*gap_dim+1]=77;   // D
+	frame_a[2*gap_dim+2]=88;   // E, stationary companion
+	frame_b[2*gap_dim+1]=77;   // D steps west: (3,1) -> (2,1), picks up west facing
+	frame_b[2*gap_dim+2]=88;   // E unchanged
+
+	// D and E both step south, chained, and F appears at D's just-vacated tile the same frame.
+	// previous[(2,1)] was occupied by D, so the empty-cell fallback cannot see F.
+	// No shared-delta source matches F's texpos either, so its arrival registers no movement.
+	frame_c[2*gap_dim+2]=77;   // D: (2,1) -> (2,2)
+	frame_c[2*gap_dim+3]=88;   // E: (2,2) -> (2,3)
+	frame_c[2*gap_dim+1]=55;   // F appears at (2,1), untracked
+
+	visual_animation_managerst manager;
+	auto input=make_input(gap_viewport,gap_dim,gap_empty);
+	set_layer(input,viewport_visual_layer::center,frame_a,gap_empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,frame_b,frame_a);
+	run_frame(manager,input,1016);
+	assert(manager.get_facing(gap_viewport,2,1)==visual_facingst::west);
+
+	set_layer(input,viewport_visual_layer::center,frame_c,frame_b);
+	run_frame(manager,input,1032);
+	assert(!manager.get_movement(
+		gap_viewport,viewport_visual_layer::center,2,1).active);
+	// F must not inherit D's stale west facing -- the tile falls back to
+	// the default (east) even though it is occupied, not empty.
+	assert(manager.get_facing(gap_viewport,2,1)==visual_facingst::east);
+	assert(manager.get_facing(gap_viewport,2,2)==visual_facingst::west);
+	assert(manager.get_facing(gap_viewport,2,3)==visual_facingst::east);
+	}
+
 	assert(animation_progress(100,0,100)==1.0f);
 	assert(inherited_visual_source_tile(0,0,1)==-1);
 	assert(inherited_visual_source_tile(2,0,1)==1);

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -243,6 +243,75 @@ int main()
 	assert(diagonal.get_facing(diag_viewport,2,2)==visual_facingst::west);
 	}
 
+	// Facing is keyed by SCREEN tile, so a scroll moves the creatures out from under it.
+	// The two outcomes differ fundamentally: a landed shift has a known delta and is translated.
+	// An abandoned shift never identifies a delta, so the grid can only be dropped.
+	{
+	constexpr int32_t pan_dim=4;
+	int32_t pan_empty[pan_dim*pan_dim]={};
+	int32_t at_one[pan_dim*pan_dim]={};
+	int32_t at_two[pan_dim*pan_dim]={};
+	const int pan_token=0;
+	const void *pan_viewport=&pan_token;
+
+	at_one[1*pan_dim+1]=77;
+	at_two[2*pan_dim+1]=77;   // steps east, x 1 -> 2, so it faces east
+
+	// LANDED: the shift is recognized, so facing follows the buffers.
+	{
+	visual_animation_managerst landed;
+	auto input=make_input(pan_viewport,pan_dim,pan_empty);
+	set_layer(input,viewport_visual_layer::center,at_one,pan_empty);
+	run_frame(landed,input,1000);
+	set_layer(input,viewport_visual_layer::center,at_two,at_one);
+	run_frame(landed,input,1016);
+	assert(landed.get_facing(pan_viewport,2,1)==visual_facingst::east);
+	assert(landed.has_mirrored_facing(pan_viewport));
+
+	// Frame A: the scroll is announced but the buffers have not moved yet.
+	input.pan_x=1;
+	set_layer(input,viewport_visual_layer::center,at_two,at_two);
+	run_frame(landed,input,1032);
+	assert(landed.get_facing(pan_viewport,2,1)==visual_facingst::east);
+
+	// Frame B: the buffers shift east by one and the majority-match test recognizes it.
+	set_layer(input,viewport_visual_layer::center,at_one,at_two);
+	run_frame(landed,input,1048);
+	assert(landed.get_facing(pan_viewport,1,1)==visual_facingst::east);
+	assert(landed.get_facing(pan_viewport,2,1)==native_sprite_facing);
+	assert(landed.has_mirrored_facing(pan_viewport));
+	}
+
+	// ABANDONED: the shift never shows up in the buffers, so no delta is ever identified.
+	// The grid must be back at the default while the tile is still OCCUPIED.
+	// The empty-tile sweep cannot reach that case, so only an explicit reset clears it.
+	{
+	visual_animation_managerst abandoned;
+	auto input=make_input(pan_viewport,pan_dim,pan_empty);
+	set_layer(input,viewport_visual_layer::center,at_one,pan_empty);
+	run_frame(abandoned,input,2000);
+	set_layer(input,viewport_visual_layer::center,at_two,at_one);
+	run_frame(abandoned,input,2016);
+	assert(abandoned.get_facing(pan_viewport,2,1)==visual_facingst::east);
+
+	// The buffers stay put, so the majority-match test fails every frame.
+	// It tolerates four before giving up on the fifth.
+	input.pan_x=1;
+	set_layer(input,viewport_visual_layer::center,at_two,at_two);
+	for(int32_t frame=0;frame<4;++frame)
+		{
+		run_frame(abandoned,input,2032+uint32_t(frame)*16);
+		// Still pending, so the facing survives.
+		// The assertion after the giving-up frame therefore tests the reset, not an empty grid.
+		assert(abandoned.get_facing(pan_viewport,2,1)==visual_facingst::east);
+		assert(abandoned.has_mirrored_facing(pan_viewport));
+		}
+	run_frame(abandoned,input,2096);
+	assert(abandoned.get_facing(pan_viewport,2,1)==native_sprite_facing);
+	assert(!abandoned.has_mirrored_facing(pan_viewport));
+	}
+	}
+
 	// Regression: A and B move in the same frame, chained -- A's target tile is B's source tile.
 	// A's write must not corrupt B's read of its own pre-frame facing.
 	// A is sent east first, so its facing differs from the default B carries and a swap shows.

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -278,6 +278,8 @@ class visual_animation_managerst
 		// One facing per tile, keyed by tile rather than by unit.
 		// The viewport exposes one creature texpos per tile, so DF has already picked it.
 		std::vector<int8_t> facing;
+		// Stationary mirrored creatures are repainted every frame; this is the cheap pre-check.
+		bool has_mirrored=false;
 		int32_t pan_x=0;
 		int32_t pan_y=0;
 		bool has_pan=false;
@@ -401,6 +403,7 @@ class visual_animation_managerst
 				{
 				reset_tracking(state);
 				state.has_context=false;
+				state.has_mirrored=false;
 				return;
 				}
 
@@ -430,9 +433,12 @@ class visual_animation_managerst
 			state.pan_y=input.pan_y;
 			state.has_pan=true;
 			if(context_changed)
+				{
 				state.facing.assign(
 					size_t(input.dim_x)*size_t(input.dim_y),
 					int8_t(native_sprite_facing));
+				state.has_mirrored=false;
+				}
 			if(context_changed||!allow_new_movements)
 				{
 				reset_tracking(state);
@@ -690,14 +696,21 @@ class visual_animation_managerst
 							!visual_layer_matches(movement.layer,current,movement.texpos);
 						}),
 				state.movements.end());
+			// has_mirrored is recomputed here rather than maintained at every write site.
 			if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
 				{
 				const int32_t *center_current=
 					input.current[static_cast<size_t>(
 						viewport_visual_layer::center)];
+				bool any_mirrored=false;
 				for(size_t i=0;i<state.facing.size();++i)
+					{
 					if(center_current[i]==0)
 						state.facing[i]=int8_t(native_sprite_facing);
+					else if(state.facing[i]!=int8_t(native_sprite_facing))
+						any_mirrored=true;
+					}
+				state.has_mirrored=any_mirrored;
 				}
 			if(!state.movements.empty())force_full_redraw=true;
 			}
@@ -740,6 +753,17 @@ class visual_animation_managerst
 				return static_cast<visual_facingst>(state.facing[index]);
 				}
 			return native_sprite_facing;
+			}
+
+		// The render path must then keep painting with no movement in flight.
+		bool has_mirrored_facing(const void *viewport) const
+			{
+			for(const viewport_animationst &state:viewports)
+				{
+				if(state.viewport!=viewport)continue;
+				return state.has_mirrored;
+				}
+			return false;
 			}
 
 		bool requires_full_redraw() const

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -271,6 +271,9 @@ class visual_animation_managerst
 		bool has_context=false;
 		bool seen=false;
 		std::vector<movementst> movements;
+		// One facing per tile, keyed by tile rather than by unit.
+		// The viewport exposes one creature texpos per tile, so DF has already picked it.
+		std::vector<int8_t> facing;
 		int32_t pan_x=0;
 		int32_t pan_y=0;
 		bool has_pan=false;
@@ -422,6 +425,10 @@ class visual_animation_managerst
 			state.pan_x=input.pan_x;
 			state.pan_y=input.pan_y;
 			state.has_pan=true;
+			if(context_changed)
+				state.facing.assign(
+					size_t(input.dim_x)*size_t(input.dim_y),
+					int8_t(visual_facingst::east));
 			if(context_changed||!allow_new_movements)
 				{
 				reset_tracking(state);
@@ -485,6 +492,27 @@ class visual_animation_managerst
 									movement.target_y<0||movement.target_y>=input.dim_y;
 								}),
 						state.movements.end());
+					// Facing describes creatures still on screen, not motion in progress.
+					// A landed pan therefore translates it instead of dropping it.
+					if(state.facing.size()==
+						size_t(input.dim_x)*size_t(input.dim_y))
+						{
+						std::vector<int8_t> shifted(
+							state.facing.size(),int8_t(visual_facingst::east));
+						for(int32_t x=0;x<input.dim_x;++x)
+							{
+							const int32_t sx=x+dwx;
+							if(sx<0||sx>=input.dim_x)continue;
+							for(int32_t y=0;y<input.dim_y;++y)
+								{
+								const int32_t sy=y+dwy;
+								if(sy<0||sy>=input.dim_y)continue;
+								shifted[x*input.dim_y+y]=
+									state.facing[sx*input.dim_y+sy];
+								}
+							}
+						state.facing.swap(shifted);
+						}
 					clear_pending(state);
 					translated=true;
 					}
@@ -504,6 +532,16 @@ class visual_animation_managerst
 				const int32_t tile_count=input.dim_x*input.dim_y;
 				std::vector<uint8_t> claimed_sources(tile_count);
 				const size_t existing_movement_count=state.movements.size();
+				// Source facing is read from a frame-start snapshot.
+				// A chained movement's source may already have been rewritten earlier this frame.
+				const std::vector<int8_t> facing_at_frame_start=state.facing;
+				// Source clears are deferred until every movement this frame is registered.
+				// A source can be another movement's target in the same frame -- a chain.
+				// Clearing inline is order-dependent: it stomps that target write, or loses to it.
+				std::vector<uint8_t> facing_target_written;
+				std::vector<int32_t> pending_facing_source_clears;
+				if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
+					facing_target_written.assign(state.facing.size(),0);
 				for(size_t layer=0;layer<input.current.size();++layer)
 					{
 					if(!visual_layer_tracks_own_movement(
@@ -602,10 +640,38 @@ class visual_animation_managerst
 								y,
 								frame_time_ms
 								});
+							if(static_cast<viewport_visual_layer>(layer)==
+									viewport_visual_layer::center&&
+								state.facing.size()==
+									size_t(input.dim_x)*size_t(input.dim_y)&&
+								!facing_at_frame_start.empty()&&
+								facing_at_frame_start.size()==state.facing.size())
+								{
+								const int32_t source_tile_x=source/input.dim_y;
+								const int32_t target_index=x*input.dim_y+y;
+								state.facing[target_index]=int8_t(
+									facing_after_move(
+										x-source_tile_x,
+										static_cast<visual_facingst>(
+											facing_at_frame_start[source])));
+								facing_target_written[size_t(target_index)]=1;
+								pending_facing_source_clears.push_back(source);
+								}
 							}
 						}
 						}
+				// A source vacates its tile only if no movement this frame claimed it as a target.
+				// That covers the in-pass chain and an untracked creature occupying the tile.
+				if(!facing_target_written.empty())
+					{
+					for(int32_t pending_source:pending_facing_source_clears)
+						{
+						if(!facing_target_written[size_t(pending_source)])
+							state.facing[size_t(pending_source)]=
+								int8_t(visual_facingst::east);
+						}
 					}
+				}
 			state.movements.erase(
 				std::remove_if(
 					state.movements.begin(),
@@ -620,6 +686,15 @@ class visual_animation_managerst
 							!visual_layer_matches(movement.layer,current,movement.texpos);
 						}),
 				state.movements.end());
+			if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
+				{
+				const int32_t *center_current=
+					input.current[static_cast<size_t>(
+						viewport_visual_layer::center)];
+				for(size_t i=0;i<state.facing.size();++i)
+					if(center_current[i]==0)
+						state.facing[i]=int8_t(visual_facingst::east);
+				}
 			if(!state.movements.empty())force_full_redraw=true;
 			}
 
@@ -645,6 +720,22 @@ class visual_animation_managerst
 		uint32_t get_frame_delta_ms() const
 			{
 			return frame_delta_ms;
+			}
+
+		visual_facingst get_facing(
+			const void *viewport,
+			int32_t x,
+			int32_t y) const
+			{
+			for(const viewport_animationst &state:viewports)
+				{
+				if(state.viewport!=viewport)continue;
+				if(x<0||x>=state.dim_x||y<0||y>=state.dim_y)break;
+				const size_t index=size_t(x)*size_t(state.dim_y)+size_t(y);
+				if(index>=state.facing.size())break;
+				return static_cast<visual_facingst>(state.facing[index]);
+				}
+			return visual_facingst::east;
 			}
 
 		bool requires_full_redraw() const

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -231,6 +231,10 @@ enum class visual_facingst : int8_t
 	west=1
 };
 
+// DF creature art faces west: an unmirrored blit already faces west, so only east needs flipping.
+// Also the default and cleared value -- a tile nothing wrote must not be marked for mirroring.
+constexpr visual_facingst native_sprite_facing=visual_facingst::west;
+
 // Sticky facing: only a horizontal component changes it.
 // Vertical-only movement and standing still carry the previous facing, not the default.
 constexpr visual_facingst facing_after_move(
@@ -428,7 +432,7 @@ class visual_animation_managerst
 			if(context_changed)
 				state.facing.assign(
 					size_t(input.dim_x)*size_t(input.dim_y),
-					int8_t(visual_facingst::east));
+					int8_t(native_sprite_facing));
 			if(context_changed||!allow_new_movements)
 				{
 				reset_tracking(state);
@@ -498,7 +502,7 @@ class visual_animation_managerst
 						size_t(input.dim_x)*size_t(input.dim_y))
 						{
 						std::vector<int8_t> shifted(
-							state.facing.size(),int8_t(visual_facingst::east));
+							state.facing.size(),int8_t(native_sprite_facing));
 						for(int32_t x=0;x<input.dim_x;++x)
 							{
 							const int32_t sx=x+dwx;
@@ -668,7 +672,7 @@ class visual_animation_managerst
 						{
 						if(!facing_target_written[size_t(pending_source)])
 							state.facing[size_t(pending_source)]=
-								int8_t(visual_facingst::east);
+								int8_t(native_sprite_facing);
 						}
 					}
 				}
@@ -693,7 +697,7 @@ class visual_animation_managerst
 						viewport_visual_layer::center)];
 				for(size_t i=0;i<state.facing.size();++i)
 					if(center_current[i]==0)
-						state.facing[i]=int8_t(visual_facingst::east);
+						state.facing[i]=int8_t(native_sprite_facing);
 				}
 			if(!state.movements.empty())force_full_redraw=true;
 			}
@@ -735,7 +739,7 @@ class visual_animation_managerst
 				if(index>=state.facing.size())break;
 				return static_cast<visual_facingst>(state.facing[index]);
 				}
-			return visual_facingst::east;
+			return native_sprite_facing;
 			}
 
 		bool requires_full_redraw() const

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -225,6 +225,30 @@ inline int32_t inherited_visual_source_tile(
 	return overlay_target+int32_t(std::lround(center_source-center_target));
 }
 
+enum class visual_facingst : int8_t
+{
+	east=0,
+	west=1
+};
+
+// Sticky facing: only a horizontal component changes it.
+// Vertical-only movement and standing still carry the previous facing, not the default.
+constexpr visual_facingst facing_after_move(
+	int32_t dx,
+	visual_facingst previous)
+{
+	if(dx>0)return visual_facingst::east;
+	if(dx<0)return visual_facingst::west;
+	return previous;
+}
+
+// The reflection is general, but the layer set is not: center_x is only -1, 0 or +1.
+// A creature is therefore at most three columns wide here; anything wider is not representable.
+constexpr int32_t mirrored_tile_x(int32_t piece_x,int32_t anchor_x)
+{
+	return anchor_x-(piece_x-anchor_x);
+}
+
 class visual_animation_managerst
 {
 	struct movementst

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -312,6 +312,15 @@ class visual_animation_managerst
 		clear_pending(state);
 		}
 
+	static void reset_facing(viewport_animationst &state)
+		{
+		std::fill(
+			state.facing.begin(),
+			state.facing.end(),
+			int8_t(native_sprite_facing));
+		state.has_mirrored=false;
+		}
+
 	static void reset_tracking(viewport_animationst &state)
 		{
 		abandon_pending(state);
@@ -441,6 +450,9 @@ class visual_animation_managerst
 				}
 			if(context_changed||!allow_new_movements)
 				{
+				// Skips the recompute sweep, so clear has_mirrored here or a stale true survives.
+				// The grid stays: an inactive viewport is not drawn and its facings still hold.
+				state.has_mirrored=false;
 				reset_tracking(state);
 				return;
 				}
@@ -483,6 +495,7 @@ class visual_animation_managerst
 					{
 					// Nothing visible to anchor the test on: nothing to animate either.
 					abandon_pending(state);
+					reset_facing(state);
 					}
 				else if(matches*2>=considered)
 					{
@@ -531,6 +544,8 @@ class visual_animation_managerst
 					// The shift never showed up recognizably (heavy simultaneous movement, culled
 					// render, ...): fall back to the safe reset behavior.
 					abandon_pending(state);
+					// The delta was never identified, so the grid cannot be translated -- drop it.
+					reset_facing(state);
 					}
 				}
 


### PR DESCRIPTION
Added sprite flipping, works as a sticky system.

Creatures that move right will flip their sprite and _sticks_ that sprite direction until moving a different direction.

<img width="2010" height="857" alt="image" src="https://github.com/user-attachments/assets/7ca1f7ac-dcee-4794-bfd9-a47fe003b1d2" />
