### PR TITLE
Fix/camera pan sprite jiggle

### DIFF
--- a/visual_animation.h
+++ b/visual_animation.h
@@ -284,8 +284,7 @@ class visual_animation_managerst
 		int32_t pan_y=0;
 		bool has_pan=false;
 		// Window scrolls not yet observed in the buffers, oldest first.
-		// A signed total instead of a queue cancels on a drag that reverses direction, and a zero
-		// total reads as "no pan outstanding" while the buffers still owe both shifts.
+		// A signed total would cancel on a reversing drag while both shifts are still owed.
 		std::vector<std::array<int32_t,2>> pending;
 		// Frames the head has gone unrecognized, and how long the queue has waited in total.
 		int32_t pending_frames=0;
@@ -295,6 +294,8 @@ class visual_animation_managerst
 		// Contents of the buffers last time they were interpreted, to recognize a repeat of them.
 		uint64_t buffer_signature=0;
 		bool has_buffer_signature=false;
+		// Set while the previous buffer still belongs to a view that has been left behind.
+		bool previous_view_stale=false;
 	};
 
 	uint32_t frame_time_ms=0;
@@ -355,9 +356,8 @@ class visual_animation_managerst
 		return hash;
 		}
 
-	// Fraction of visible tracked sprites consistent with the buffers having shifted by (dwx,dwy).
-	// A scroll of that much moves world content so that current[x] == previous[x+dwx], same for y.
-	// Negative when there is nothing to compare against.
+	// Fraction of visible tracked sprites consistent with a buffer shift of (dwx,dwy), which
+	// leaves current[x] == previous[x+dwx], same for y. Negative when there is nothing to compare.
 	static double shift_match_ratio(
 		const viewport_visual_animation_inputst &input,
 		int32_t dwx,
@@ -482,9 +482,12 @@ class visual_animation_managerst
 				return;
 				}
 
-			const bool context_changed=!state.has_context||
-				state.context_revision!=input.context_revision||
-				state.dim_x!=input.dim_x||state.dim_y!=input.dim_y;
+			// Only a replaced view leaves a previous buffer belonging somewhere else; a first
+			// sighting does not.
+			const bool view_switched=state.has_context&&
+				(state.context_revision!=input.context_revision||
+				state.dim_x!=input.dim_x||state.dim_y!=input.dim_y);
+			const bool context_changed=!state.has_context||view_switched;
 			// A pure map scroll is followable, but window_x/window_y change at INPUT time while the
 			// viewport buffers shift on a later render frame. So the scroll delta is only accumulated
 			// here as a pending hint; the buffers themselves are hypothesis-tested each frame to find
@@ -515,11 +518,8 @@ class visual_animation_managerst
 					int8_t(native_sprite_facing));
 				state.has_mirrored=false;
 				}
-			// DF hands the same buffer pair to more than one render frame: this hook runs per frame
-			// while the viewport is recomputed only when it changes, and a paused game barely
-			// recomputes it at all. A landed scroll therefore stays visible after it was consumed,
-			// and reading it a second time turns one pan into a one-tile step for every sprite on
-			// screen. Only a viewport that actually advanced says anything new about movement.
+			// This hook runs per frame; the viewport is recomputed only when it changes, and while
+			// paused hardly at all. Re-reading a landed scroll steps every sprite by a tile.
 			const uint64_t signature=compute_buffer_signature(input);
 			const bool buffers_advanced=!state.has_buffer_signature||
 				state.buffer_signature!=signature;
@@ -532,17 +532,23 @@ class visual_animation_managerst
 				// The grid stays: an inactive viewport is not drawn and its facings still hold.
 				state.has_mirrored=false;
 				reset_tracking(state);
+				// window_z, zoom and resize change at input time; the buffers cross later.
+				// This reset covers only the input frame, not the crossing itself.
+				if(view_switched||!allow_new_movements)state.previous_view_stale=true;
 				return;
 				}
 
+			// On the crossing frame `current` is the new view and `previous` the old one, so a
+			// sprite on each side, a tile apart, reads as one that moved between them.
+			const bool crossed_views=buffers_advanced&&state.previous_view_stale;
+			if(buffers_advanced)state.previous_view_stale=false;
+
 			bool translated=false;
-			if(buffers_advanced&&!state.pending.empty())
+			if(buffers_advanced&&!crossed_views&&!state.pending.empty())
 				{
-				// The buffers apply queued scrolls in order and may coalesce them, so each hypothesis
-				// is a prefix of the queue.
-				// Prefixes are tried shortest first, since distinct ones can share a cumulative delta.
-				// [+1,+1,-1] nets +1 at one entry and at three, and retiring more than the buffers
-				// applied leaves owed shifts to be read as creature movement.
+				// Queued scrolls land in order and may coalesce, so each hypothesis is a prefix.
+				// Shortest first: prefixes can share a delta ([+1,+1,-1] nets +1 at one and at
+				// three), and over-retiring leaves owed shifts to be read as movement.
 				std::array<int32_t,2> landed{};
 				size_t landed_count=0;
 				bool no_data=false;
@@ -638,7 +644,7 @@ class visual_animation_managerst
 					}
 				}
 
-			const bool suppress=!buffers_advanced||translated||
+			const bool suppress=!buffers_advanced||crossed_views||translated||
 				!state.pending.empty()||state.suppress_frames>0;
 			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
 			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -544,6 +544,7 @@ class visual_animation_managerst
 			if(buffers_advanced)state.previous_view_stale=false;
 
 			bool translated=false;
+			std::array<int32_t,2> landed_shift{};
 			if(buffers_advanced&&!crossed_views&&!state.pending.empty())
 				{
 				// Queued scrolls land in order and may coalesce, so each hypothesis is a prefix.
@@ -625,6 +626,10 @@ class visual_animation_managerst
 						state.pending.begin()+int32_t(landed_count));
 					state.pending_frames=0;
 					state.pending_age=0;
+					// A landing accounts for the scroll, so the settle window has nothing left to
+					// guard against and must not suppress the rebased pass below.
+					state.suppress_frames=0;
+					landed_shift=landed;
 					translated=true;
 					}
 				else if(shift_match_ratio(input,0,0)>=0.5&&
@@ -644,7 +649,36 @@ class visual_animation_managerst
 					}
 				}
 
-			const bool suppress=!buffers_advanced||crossed_views||translated||
+			// On the frame a scroll lands, `previous` is still framed on the pre-scroll view.
+			// Rebasing it by the landed delta makes the comparison valid again: stationary content
+			// then matches exactly and yields nothing, while a creature that walked during the
+			// scroll is still recognized instead of losing its facing to the tile it vacated.
+			auto previous_layers=input.previous;
+			std::vector<std::vector<int32_t>> rebased_previous;
+			if(translated&&(landed_shift[0]!=0||landed_shift[1]!=0))
+				{
+				rebased_previous.resize(input.previous.size());
+				for(size_t layer=0;layer<input.previous.size();++layer)
+					{
+					rebased_previous[layer].assign(
+						size_t(input.dim_x)*size_t(input.dim_y),0);
+					for(int32_t x=0;x<input.dim_x;++x)
+						{
+						const int32_t sx=x+landed_shift[0];
+						if(sx<0||sx>=input.dim_x)continue;
+						for(int32_t y=0;y<input.dim_y;++y)
+							{
+							const int32_t sy=y+landed_shift[1];
+							if(sy<0||sy>=input.dim_y)continue;
+							rebased_previous[layer][x*input.dim_y+y]=
+								input.previous[layer][sx*input.dim_y+sy];
+							}
+						}
+					previous_layers[layer]=rebased_previous[layer].data();
+					}
+				}
+
+			const bool suppress=!buffers_advanced||crossed_views||
 				!state.pending.empty()||state.suppress_frames>0;
 			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
 			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;
@@ -669,7 +703,7 @@ class visual_animation_managerst
 						static_cast<viewport_visual_layer>(layer)))continue;
 					std::fill(claimed_sources.begin(),claimed_sources.end(),0);
 					const int32_t *current=input.current[layer];
-					const int32_t *previous=input.previous[layer];
+					const int32_t *previous=previous_layers[layer];
 					const auto shared_delta=
 						static_cast<viewport_visual_layer>(layer)==viewport_visual_layer::center?
 						shared_movement_delta(
@@ -684,7 +718,7 @@ class visual_animation_managerst
 							if(texpos==0)continue;
 							if(static_cast<viewport_visual_layer>(layer)==
 								viewport_visual_layer::item&&
-								input.previous[static_cast<size_t>(
+								previous_layers[static_cast<size_t>(
 									viewport_visual_layer::center)][target]!=0)continue;
 
 							int32_t source=-1;

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -132,12 +132,7 @@ struct viewport_visual_animation_inputst
 	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> current{};
 	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> previous{};
 	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision.
-	// The scroll value is only a HINT: it changes at input time, while the viewport buffers shift
-	// on a later render frame. The manager hypothesis-tests the buffers to find the frame the
-	// shift actually lands, translates in-flight movements on that frame (so sprites track the
-	// scrolled world), and suppresses new-movement detection while a pan is pending -- otherwise
-	// the shifted buffers make every panned creature look like a real move and it slides across
-	// the screen (the "floating sprites while jiggling the camera" bug).
+	// Only a hint: it changes at input time, the buffers shift on a later render frame.
 	int32_t pan_x=0;
 	int32_t pan_y=0;
 
@@ -231,12 +226,10 @@ enum class visual_facingst : int8_t
 	west=1
 };
 
-// DF creature art faces west: an unmirrored blit already faces west, so only east needs flipping.
-// Also the default and cleared value -- a tile nothing wrote must not be marked for mirroring.
+// DF creature art faces west, so only east needs flipping. Also the default and cleared value.
 constexpr visual_facingst native_sprite_facing=visual_facingst::west;
 
 // Sticky facing: only a horizontal component changes it.
-// Vertical-only movement and standing still carry the previous facing, not the default.
 constexpr visual_facingst facing_after_move(
 	int32_t dx,
 	visual_facingst previous)
@@ -246,8 +239,7 @@ constexpr visual_facingst facing_after_move(
 	return previous;
 }
 
-// The reflection is general, but the layer set is not: center_x is only -1, 0 or +1.
-// A creature is therefore at most three columns wide here; anything wider is not representable.
+// center_x is only -1, 0 or +1, so a creature is at most three columns wide here.
 constexpr int32_t mirrored_tile_x(int32_t piece_x,int32_t anchor_x)
 {
 	return anchor_x-(piece_x-anchor_x);
@@ -275,8 +267,7 @@ class visual_animation_managerst
 		bool has_context=false;
 		bool seen=false;
 		std::vector<movementst> movements;
-		// One facing per tile, keyed by tile rather than by unit.
-		// The viewport exposes one creature texpos per tile, so DF has already picked it.
+		// One facing per tile, not per unit: the viewport exposes one creature texpos per tile.
 		std::vector<int8_t> facing;
 		// Stationary mirrored creatures are repainted every frame; this is the cheap pre-check.
 		bool has_mirrored=false;
@@ -286,12 +277,13 @@ class visual_animation_managerst
 		// Window scrolls not yet observed in the buffers, oldest first.
 		// A signed total would cancel on a reversing drag while both shifts are still owed.
 		std::vector<std::array<int32_t,2>> pending;
-		// Frames the head has gone unrecognized, and how long the queue has waited in total.
+		// Redraws no prefix has matched.
 		int32_t pending_frames=0;
+		// Redraws spent waiting for the buffers to move at all.
 		int32_t pending_age=0;
-		// Frames left in which new-movement detection stays suppressed after scroll activity.
+		// Redraws left in which new-movement detection stays suppressed after scroll activity.
 		int32_t suppress_frames=0;
-		// Contents of the buffers last time they were interpreted, to recognize a repeat of them.
+		// Buffer contents last seen, to recognize a repeat of them.
 		uint64_t buffer_signature=0;
 		bool has_buffer_signature=false;
 		// Set while the previous buffer still belongs to a view that has been left behind.
@@ -356,8 +348,8 @@ class visual_animation_managerst
 		return hash;
 		}
 
-	// Fraction of visible tracked sprites consistent with a buffer shift of (dwx,dwy), which
-	// leaves current[x] == previous[x+dwx], same for y. Negative when there is nothing to compare.
+	// Fraction of tracked sprites consistent with a buffer shift: current[x]==previous[x+dwx].
+	// Negative when there is nothing to compare.
 	static double shift_match_ratio(
 		const viewport_visual_animation_inputst &input,
 		int32_t dwx,
@@ -367,8 +359,11 @@ class visual_animation_managerst
 		int32_t matches=0;
 		for(size_t layer=0;layer<input.current.size();++layer)
 			{
-			if(!visual_layer_tracks_own_movement(
-				static_cast<viewport_visual_layer>(layer)))continue;
+			const auto id=static_cast<viewport_visual_layer>(layer);
+			if(!visual_layer_tracks_own_movement(id))continue;
+			// A layer matching any non-zero previous carries no position, so it would vote for
+			// every hypothesis and carry an unapplied scroll over the bar.
+			if(visual_layer_descriptor(id).matches_any_previous)continue;
 			const int32_t *current=input.current[layer];
 			const int32_t *previous=input.previous[layer];
 			for(int32_t x=0;x<input.dim_x;++x)
@@ -382,10 +377,7 @@ class visual_animation_managerst
 					const int32_t sy=y+dwy;
 					if(sy<0||sy>=input.dim_y)continue;
 					++considered;
-					if(visual_layer_matches(
-						static_cast<viewport_visual_layer>(layer),
-						texpos,
-						previous[sx*input.dim_y+sy]))++matches;
+					if(visual_layer_matches(id,texpos,previous[sx*input.dim_y+sy]))++matches;
 					}
 				}
 			}
@@ -488,17 +480,17 @@ class visual_animation_managerst
 				(state.context_revision!=input.context_revision||
 				state.dim_x!=input.dim_x||state.dim_y!=input.dim_y);
 			const bool context_changed=!state.has_context||view_switched;
-			// A pure map scroll is followable, but window_x/window_y change at INPUT time while the
-			// viewport buffers shift on a later render frame. So the scroll delta is only accumulated
-			// here as a pending hint; the buffers themselves are hypothesis-tested each frame to find
-			// the frame the shift really lands. On that frame in-flight movements are translated so
-			// they track the scrolled world. While a pan is pending (and briefly after), new-movement
-			// detection is suppressed: a shifted buffer makes every panned creature look like a
-			// "unique same-sprite move between empty cells", which is exactly the bogus 100ms slide
-			// that made sprites float when the camera moved.
+			// The scroll delta is queued here as a hint; the buffers are hypothesis-tested each
+			// frame to find where it lands. Detection stays suppressed until then: a shifted
+			// buffer makes every panned creature look like a real move.
 			if(state.has_pan&&(state.pan_x!=input.pan_x||state.pan_y!=input.pan_y))
 				{
-				if(state.pending.size()>=max_pending_shifts)abandon_pending(state);
+				if(state.pending.size()>=max_pending_shifts)
+					{
+					// Same give-up as the other two sites: the owed shifts are unknowable now.
+					abandon_pending(state);
+					reset_facing(state);
+					}
 				state.pending.push_back(
 					{input.pan_x-state.pan_x,input.pan_y-state.pan_y});
 				state.pending_frames=0;
@@ -542,17 +534,19 @@ class visual_animation_managerst
 			// sprite on each side, a tile apart, reads as one that moved between them.
 			const bool crossed_views=buffers_advanced&&state.previous_view_stale;
 			if(buffers_advanced)state.previous_view_stale=false;
+			// The new view is drawn at the current window, so a queued scroll is already in it.
+			// Left queued it would never match, and suppress everything until it aged out.
+			if(crossed_views)clear_pending(state);
 
 			bool translated=false;
 			std::array<int32_t,2> landed_shift{};
 			if(buffers_advanced&&!crossed_views&&!state.pending.empty())
 				{
 				// Queued scrolls land in order and may coalesce, so each hypothesis is a prefix.
-				// Shortest first: prefixes can share a delta ([+1,+1,-1] nets +1 at one and at
-				// three), and over-retiring leaves owed shifts to be read as movement.
+				// Shortest first: over-retiring leaves owed shifts to be read as movement.
 				std::array<int32_t,2> landed{};
 				size_t landed_count=0;
-				bool no_data=false;
+				bool any_data=false;
 				std::array<int32_t,2> shift{};
 				for(size_t count=1;count<=state.pending.size();++count)
 					{
@@ -562,11 +556,10 @@ class visual_animation_managerst
 					// Accepting it would retire shifts the buffers have still to apply.
 					if(shift[0]==0&&shift[1]==0)continue;
 					const double ratio=shift_match_ratio(input,shift[0],shift[1]);
-					if(ratio<0.0)
-						{
-						no_data=true;
-						break;
-						}
+					// Emptiness is per-prefix: a long one can push every sprite out of range
+					// while a shorter one still has something to say.
+					if(ratio<0.0)continue;
+					any_data=true;
 					if(ratio>=0.5)
 						{
 						landed=shift;
@@ -574,7 +567,7 @@ class visual_animation_managerst
 						break;
 						}
 					}
-				if(no_data)
+				if(!any_data)
 					{
 					// Nothing visible to anchor the test on: nothing to animate either.
 					abandon_pending(state);
@@ -582,8 +575,7 @@ class visual_animation_managerst
 					}
 				else if(landed_count>0)
 					{
-					// The shift landed: re-anchor in-flight movements to the new viewport frame and
-					// drop anything scrolled off-screen.
+					// Re-anchor in-flight movements and drop anything scrolled off-screen.
 					const int32_t dwx=landed[0];
 					const int32_t dwy=landed[1];
 					state.movements.erase(
@@ -600,8 +592,7 @@ class visual_animation_managerst
 									movement.target_y<0||movement.target_y>=input.dim_y;
 								}),
 						state.movements.end());
-					// Facing describes creatures still on screen, not motion in progress.
-					// A landed pan therefore translates it instead of dropping it.
+					// Facing describes creatures still on screen, so translate it rather than drop it.
 					if(state.facing.size()==
 						size_t(input.dim_x)*size_t(input.dim_y))
 						{
@@ -623,11 +614,10 @@ class visual_animation_managerst
 						}
 					state.pending.erase(
 						state.pending.begin(),
-						state.pending.begin()+int32_t(landed_count));
+						state.pending.begin()+std::ptrdiff_t(landed_count));
 					state.pending_frames=0;
 					state.pending_age=0;
-					// A landing accounts for the scroll, so the settle window has nothing left to
-					// guard against and must not suppress the rebased pass below.
+					// The scroll is accounted for; the settle window must not block the rebased pass.
 					state.suppress_frames=0;
 					landed_shift=landed;
 					translated=true;
@@ -635,31 +625,36 @@ class visual_animation_managerst
 				else if(shift_match_ratio(input,0,0)>=0.5&&
 					++state.pending_age<=max_pending_age_frames)
 					{
-					// The buffers demonstrably have not moved yet, so the scroll is still in flight.
-					// Waiting is not a failure here; only the age cap bounds it.
+					// The buffers have not moved yet, so the scroll is still in flight.
 					state.pending_frames=0;
 					}
 				else if(++state.pending_frames>4)
 					{
-					// The shift never showed up recognizably (heavy simultaneous movement, culled
-					// render, ...): fall back to the safe reset behavior.
+					// The shift never showed up recognizably: fall back to the safe reset.
 					abandon_pending(state);
-					// The delta was never identified, so the grid cannot be translated -- drop it.
+					// The delta was never identified, so the grid cannot be translated.
 					reset_facing(state);
+					// It may yet land, so do not resume detection on the very next redraw.
+					state.suppress_frames=2;
 					}
 				}
 
-			// On the frame a scroll lands, `previous` is still framed on the pre-scroll view.
-			// Rebasing it by the landed delta makes the comparison valid again: stationary content
-			// then matches exactly and yields nothing, while a creature that walked during the
-			// scroll is still recognized instead of losing its facing to the tile it vacated.
+			const bool suppress=!buffers_advanced||crossed_views||
+				!state.pending.empty()||state.suppress_frames>0;
+			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
+			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;
+
+			// On the landing frame `previous` is still framed on the pre-scroll view.
+			// Rebasing it by the landed delta keeps a creature that walked during the scroll.
 			auto previous_layers=input.previous;
 			std::vector<std::vector<int32_t>> rebased_previous;
-			if(translated&&(landed_shift[0]!=0||landed_shift[1]!=0))
+			if(translated&&!suppress)
 				{
 				rebased_previous.resize(input.previous.size());
 				for(size_t layer=0;layer<input.previous.size();++layer)
 					{
+					if(!visual_layer_tracks_own_movement(
+						static_cast<viewport_visual_layer>(layer)))continue;
 					rebased_previous[layer].assign(
 						size_t(input.dim_x)*size_t(input.dim_y),0);
 					for(int32_t x=0;x<input.dim_x;++x)
@@ -677,22 +672,15 @@ class visual_animation_managerst
 					previous_layers[layer]=rebased_previous[layer].data();
 					}
 				}
-
-			const bool suppress=!buffers_advanced||crossed_views||
-				!state.pending.empty()||state.suppress_frames>0;
-			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
-			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;
 			if(!suppress)
 				{
 				const int32_t tile_count=input.dim_x*input.dim_y;
 				std::vector<uint8_t> claimed_sources(tile_count);
 				const size_t existing_movement_count=state.movements.size();
-				// Source facing is read from a frame-start snapshot.
-				// A chained movement's source may already have been rewritten earlier this frame.
+				// A chained movement's source may already have been rewritten this frame.
 				const std::vector<int8_t> facing_at_frame_start=state.facing;
 				// Source clears are deferred until every movement this frame is registered.
 				// A source can be another movement's target in the same frame -- a chain.
-				// Clearing inline is order-dependent: it stomps that target write, or loses to it.
 				std::vector<uint8_t> facing_target_written;
 				std::vector<int32_t> pending_facing_source_clears;
 				if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
@@ -816,7 +804,6 @@ class visual_animation_managerst
 						}
 						}
 				// A source vacates its tile only if no movement this frame claimed it as a target.
-				// That covers the in-pass chain and an untracked creature occupying the tile.
 				if(!facing_target_written.empty())
 					{
 					for(int32_t pending_source:pending_facing_source_clears)
@@ -900,7 +887,6 @@ class visual_animation_managerst
 			return native_sprite_facing;
 			}
 
-		// The render path must then keep painting with no movement in flight.
 		bool has_mirrored_facing(const void *viewport) const
 			{
 			for(const viewport_animationst &state:viewports)

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -292,6 +292,9 @@ class visual_animation_managerst
 		int32_t pending_age=0;
 		// Frames left in which new-movement detection stays suppressed after scroll activity.
 		int32_t suppress_frames=0;
+		// Contents of the buffers last time they were interpreted, to recognize a repeat of them.
+		uint64_t buffer_signature=0;
+		bool has_buffer_signature=false;
 	};
 
 	uint32_t frame_time_ms=0;
@@ -332,6 +335,24 @@ class visual_animation_managerst
 		{
 		abandon_pending(state);
 		state.suppress_frames=0;
+		}
+
+	// Identifies the buffer contents this frame, to tell a redrawn viewport from a repeated one.
+	static uint64_t compute_buffer_signature(const viewport_visual_animation_inputst &input)
+		{
+		uint64_t hash=1469598103934665603ULL;
+		const int32_t tile_count=input.dim_x*input.dim_y;
+		for(size_t layer=0;layer<input.current.size();++layer)
+			{
+			if(!visual_layer_tracks_own_movement(
+				static_cast<viewport_visual_layer>(layer)))continue;
+			for(int32_t i=0;i<tile_count;++i)
+				{
+				hash=(hash^uint64_t(uint32_t(input.current[layer][i])))*1099511628211ULL;
+				hash=(hash^uint64_t(uint32_t(input.previous[layer][i])))*1099511628211ULL;
+				}
+			}
+		return hash;
 		}
 
 	// Fraction of visible tracked sprites consistent with the buffers having shifted by (dwx,dwy).
@@ -494,6 +515,17 @@ class visual_animation_managerst
 					int8_t(native_sprite_facing));
 				state.has_mirrored=false;
 				}
+			// DF hands the same buffer pair to more than one render frame: this hook runs per frame
+			// while the viewport is recomputed only when it changes, and a paused game barely
+			// recomputes it at all. A landed scroll therefore stays visible after it was consumed,
+			// and reading it a second time turns one pan into a one-tile step for every sprite on
+			// screen. Only a viewport that actually advanced says anything new about movement.
+			const uint64_t signature=compute_buffer_signature(input);
+			const bool buffers_advanced=!state.has_buffer_signature||
+				state.buffer_signature!=signature;
+			state.buffer_signature=signature;
+			state.has_buffer_signature=true;
+
 			if(context_changed||!allow_new_movements)
 				{
 				// Skips the recompute sweep, so clear has_mirrored here or a stale true survives.
@@ -504,7 +536,7 @@ class visual_animation_managerst
 				}
 
 			bool translated=false;
-			if(!state.pending.empty())
+			if(buffers_advanced&&!state.pending.empty())
 				{
 				// The buffers apply queued scrolls in order and may coalesce them, so each hypothesis
 				// is a prefix of the queue.
@@ -606,9 +638,10 @@ class visual_animation_managerst
 					}
 				}
 
-			const bool suppress=translated||
+			const bool suppress=!buffers_advanced||translated||
 				!state.pending.empty()||state.suppress_frames>0;
-			if(state.suppress_frames>0)--state.suppress_frames;
+			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
+			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;
 			if(!suppress)
 				{
 				const int32_t tile_count=input.dim_x*input.dim_y;

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -283,10 +283,13 @@ class visual_animation_managerst
 		int32_t pan_x=0;
 		int32_t pan_y=0;
 		bool has_pan=false;
-		// Window-scroll delta not yet observed in the buffers, and how long it has been pending.
-		int32_t pending_dx=0;
-		int32_t pending_dy=0;
+		// Window scrolls not yet observed in the buffers, oldest first.
+		// A signed total instead of a queue cancels on a drag that reverses direction, and a zero
+		// total reads as "no pan outstanding" while the buffers still owe both shifts.
+		std::vector<std::array<int32_t,2>> pending;
+		// Frames the head has gone unrecognized, and how long the queue has waited in total.
 		int32_t pending_frames=0;
+		int32_t pending_age=0;
 		// Frames left in which new-movement detection stays suppressed after scroll activity.
 		int32_t suppress_frames=0;
 	};
@@ -298,12 +301,16 @@ class visual_animation_managerst
 	std::vector<viewport_animationst> viewports;
 
 	static constexpr uint32_t movement_duration_ms=100;
+	// Scrolling faster than detection keeps up: give up rather than test ever more prefixes.
+	static constexpr size_t max_pending_shifts=8;
+	// Bounds the wait on a scroll that never lands, so suppression cannot stick forever.
+	static constexpr int32_t max_pending_age_frames=120;
 
 	static void clear_pending(viewport_animationst &state)
 		{
-		state.pending_dx=0;
-		state.pending_dy=0;
+		state.pending.clear();
 		state.pending_frames=0;
+		state.pending_age=0;
 		}
 
 	static void abandon_pending(viewport_animationst &state)
@@ -325,6 +332,44 @@ class visual_animation_managerst
 		{
 		abandon_pending(state);
 		state.suppress_frames=0;
+		}
+
+	// Fraction of visible tracked sprites consistent with the buffers having shifted by (dwx,dwy).
+	// A scroll of that much moves world content so that current[x] == previous[x+dwx], same for y.
+	// Negative when there is nothing to compare against.
+	static double shift_match_ratio(
+		const viewport_visual_animation_inputst &input,
+		int32_t dwx,
+		int32_t dwy)
+		{
+		int32_t considered=0;
+		int32_t matches=0;
+		for(size_t layer=0;layer<input.current.size();++layer)
+			{
+			if(!visual_layer_tracks_own_movement(
+				static_cast<viewport_visual_layer>(layer)))continue;
+			const int32_t *current=input.current[layer];
+			const int32_t *previous=input.previous[layer];
+			for(int32_t x=0;x<input.dim_x;++x)
+				{
+				const int32_t sx=x+dwx;
+				if(sx<0||sx>=input.dim_x)continue;
+				for(int32_t y=0;y<input.dim_y;++y)
+					{
+					const int32_t texpos=current[x*input.dim_y+y];
+					if(texpos==0)continue;
+					const int32_t sy=y+dwy;
+					if(sy<0||sy>=input.dim_y)continue;
+					++considered;
+					if(visual_layer_matches(
+						static_cast<viewport_visual_layer>(layer),
+						texpos,
+						previous[sx*input.dim_y+sy]))++matches;
+					}
+				}
+			}
+		if(considered==0)return -1.0;
+		return double(matches)/double(considered);
 		}
 
 	static std::array<int32_t,2> shared_movement_delta(
@@ -429,8 +474,9 @@ class visual_animation_managerst
 			// that made sprites float when the camera moved.
 			if(state.has_pan&&(state.pan_x!=input.pan_x||state.pan_y!=input.pan_y))
 				{
-				state.pending_dx+=input.pan_x-state.pan_x;
-				state.pending_dy+=input.pan_y-state.pan_y;
+				if(state.pending.size()>=max_pending_shifts)abandon_pending(state);
+				state.pending.push_back(
+					{input.pan_x-state.pan_x,input.pan_y-state.pan_y});
 				state.pending_frames=0;
 				state.suppress_frames=2;
 				}
@@ -458,49 +504,49 @@ class visual_animation_managerst
 				}
 
 			bool translated=false;
-			if(state.pending_dx!=0||state.pending_dy!=0)
+			if(!state.pending.empty())
 				{
-				// Did the buffers apply the pending scroll? After a scroll of (dwx,dwy) the world
-				// content moves so that current[x] == previous[x+dwx] (same for y). Test that over
-				// the visible creature sprites; a majority match means the shift landed this frame.
-				const int32_t dwx=state.pending_dx;
-				const int32_t dwy=state.pending_dy;
-				int32_t considered=0;
-				int32_t matches=0;
-				for(size_t layer=0;layer<input.current.size();++layer)
+				// The buffers apply queued scrolls in order and may coalesce them, so each hypothesis
+				// is a prefix of the queue.
+				// Prefixes are tried shortest first, since distinct ones can share a cumulative delta.
+				// [+1,+1,-1] nets +1 at one entry and at three, and retiring more than the buffers
+				// applied leaves owed shifts to be read as creature movement.
+				std::array<int32_t,2> landed{};
+				size_t landed_count=0;
+				bool no_data=false;
+				std::array<int32_t,2> shift{};
+				for(size_t count=1;count<=state.pending.size();++count)
 					{
-					if(!visual_layer_tracks_own_movement(
-						static_cast<viewport_visual_layer>(layer)))continue;
-					const int32_t *current=input.current[layer];
-					const int32_t *previous=input.previous[layer];
-					for(int32_t x=0;x<input.dim_x;++x)
+					shift[0]+=state.pending[count-1][0];
+					shift[1]+=state.pending[count-1][1];
+					// A prefix netting to zero is indistinguishable from "nothing landed yet".
+					// Accepting it would retire shifts the buffers have still to apply.
+					if(shift[0]==0&&shift[1]==0)continue;
+					const double ratio=shift_match_ratio(input,shift[0],shift[1]);
+					if(ratio<0.0)
 						{
-						const int32_t sx=x+dwx;
-						if(sx<0||sx>=input.dim_x)continue;
-						for(int32_t y=0;y<input.dim_y;++y)
-							{
-							const int32_t texpos=current[x*input.dim_y+y];
-							if(texpos==0)continue;
-							const int32_t sy=y+dwy;
-							if(sy<0||sy>=input.dim_y)continue;
-							++considered;
-						if(visual_layer_matches(
-								static_cast<viewport_visual_layer>(layer),
-								texpos,
-								previous[sx*input.dim_y+sy]))++matches;
-							}
+						no_data=true;
+						break;
+						}
+					if(ratio>=0.5)
+						{
+						landed=shift;
+						landed_count=count;
+						break;
 						}
 					}
-				if(considered==0)
+				if(no_data)
 					{
 					// Nothing visible to anchor the test on: nothing to animate either.
 					abandon_pending(state);
 					reset_facing(state);
 					}
-				else if(matches*2>=considered)
+				else if(landed_count>0)
 					{
 					// The shift landed: re-anchor in-flight movements to the new viewport frame and
 					// drop anything scrolled off-screen.
+					const int32_t dwx=landed[0];
+					const int32_t dwy=landed[1];
 					state.movements.erase(
 						std::remove_if(
 							state.movements.begin(),
@@ -536,8 +582,19 @@ class visual_animation_managerst
 							}
 						state.facing.swap(shifted);
 						}
-					clear_pending(state);
+					state.pending.erase(
+						state.pending.begin(),
+						state.pending.begin()+int32_t(landed_count));
+					state.pending_frames=0;
+					state.pending_age=0;
 					translated=true;
+					}
+				else if(shift_match_ratio(input,0,0)>=0.5&&
+					++state.pending_age<=max_pending_age_frames)
+					{
+					// The buffers demonstrably have not moved yet, so the scroll is still in flight.
+					// Waiting is not a failure here; only the age cap bounds it.
+					state.pending_frames=0;
 					}
 				else if(++state.pending_frames>4)
 					{
@@ -550,7 +607,7 @@ class visual_animation_managerst
 				}
 
 			const bool suppress=translated||
-				state.pending_dx!=0||state.pending_dy!=0||state.suppress_frames>0;
+				!state.pending.empty()||state.suppress_frames>0;
 			if(state.suppress_frames>0)--state.suppress_frames;
 			if(!suppress)
 				{

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -333,7 +333,10 @@ class visual_animation_managerst
 	// Identifies the buffer contents this frame, to tell a redrawn viewport from a repeated one.
 	static uint64_t compute_buffer_signature(const viewport_visual_animation_inputst &input)
 		{
-		uint64_t hash=1469598103934665603ULL;
+		// FNV-1a. Only ever compared against the previous frame's value, never stored.
+		constexpr uint64_t fnv_offset_basis=0xcbf29ce484222325ULL;
+		constexpr uint64_t fnv_prime=0x100000001b3ULL;
+		uint64_t hash=fnv_offset_basis;
 		const int32_t tile_count=input.dim_x*input.dim_y;
 		for(size_t layer=0;layer<input.current.size();++layer)
 			{
@@ -341,8 +344,8 @@ class visual_animation_managerst
 				static_cast<viewport_visual_layer>(layer)))continue;
 			for(int32_t i=0;i<tile_count;++i)
 				{
-				hash=(hash^uint64_t(uint32_t(input.current[layer][i])))*1099511628211ULL;
-				hash=(hash^uint64_t(uint32_t(input.previous[layer][i])))*1099511628211ULL;
+				hash=(hash^uint64_t(uint32_t(input.current[layer][i])))*fnv_prime;
+				hash=(hash^uint64_t(uint32_t(input.previous[layer][i])))*fnv_prime;
 				}
 			}
 		return hash;


### PR DESCRIPTION
Fixed the jitter issue with the camera when paused

Came from the plugin renderer constantly updating and not caring about state changes. Also created artifacts when changing z levels