### PR TITLE
Animate lower z-level viewports / remove construction feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ticks, saves, or gameplay state.
 
 ## Compatibility
 
-v0.3.0 requires DFHack 53.15-r3 or newer and the SDL 2D renderer. DFHack C++
+v0.3.0 requires DFHack 53.16-r1 or newer and the SDL 2D renderer. DFHack C++
 plugins are ABI-specific, so rebuild the plugin whenever the DFHack or Dwarf
 Fortress version changes.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cmake --build /path/to/dfhack-build --target smooth-movement-test
 
 - Movement uses a 100 ms smoothstep interpolation.
 - Creature status icons move with their creature, including while flashing.
+- Creatures visible above or below the camera z-level animate in their own render layer.
 - Item-layer wheelbarrows and vehicle-layer minecarts are interpolated.
 - Camera panning is followed: in-flight interpolations are translated by the
   scroll delta so sprites track the world, and drop once they scroll off-screen.

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -741,6 +741,22 @@ struct render_proxyst
 	std::set<std::pair<int32_t,int32_t>> coverage;
 };
 
+using tile_coveragest=std::set<std::pair<int32_t,int32_t>>;
+
+struct render_coveragest
+{
+	tile_coveragest all;
+	std::array<tile_coveragest,static_cast<size_t>(visual_render_groupst::count)> groups;
+	std::unordered_map<int32_t,uint16_t> selected;
+};
+
+struct viewport_renderst
+{
+	df::graphic_viewportst *viewport;
+	std::vector<render_proxyst> proxies;
+	render_coveragest coverage;
+};
+
 constexpr uint16_t visual_layer_bit(viewport_visual_layer layer)
 {
 	return uint16_t(1U<<static_cast<uint8_t>(layer));
@@ -839,29 +855,31 @@ void with_incoming_tile_suppressed(
 		with_zeroed_values(callback,vp->screentexpos_building_one[index]);
 }
 
-void redraw_world_tile(
+void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
-	df::graphic_viewportst *vp,
+	const viewport_renderst &viewport,
 	int32_t x,
-	int32_t y,
-	const std::unordered_map<int32_t,uint16_t> &selected)
+	int32_t y)
 {
+	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]
-		{
-		for(int32_t lower=7;lower>=0;--lower)
-			{
-			df::graphic_viewportst *lower_vp=gps->lower_viewport[lower];
-			if(lower_vp!=nullptr&&lower_vp->flag.bits.active)
-				renderer->update_viewport_tile(lower_vp,x,y);
-			}
-		renderer->update_viewport_tile(vp,x,y);
-		};
+	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
 	with_incoming_tile_suppressed(vp,index,[&]
 		{
 		with_suppressed_visual_layers(
-			visual_layers(vp),index,selected_mask(selected,index),redraw);
+			visual_layers(vp),index,
+			selected_mask(viewport.coverage.selected,index),redraw);
 		});
+}
+
+void redraw_world_tile(
+	df::renderer_2d_base *renderer,
+	const std::vector<viewport_renderst> &viewports,
+	int32_t x,
+	int32_t y)
+{
+	for(const viewport_renderst &viewport:viewports)
+		redraw_viewport_tile(renderer,viewport,x,y);
 }
 
 constexpr uint16_t visual_layers_through_group(visual_render_groupst group)
@@ -1239,15 +1257,6 @@ std::vector<render_proxyst> collect_proxies(
 	return proxies;
 }
 
-using tile_coveragest=std::set<std::pair<int32_t,int32_t>>;
-
-struct render_coveragest
-{
-	tile_coveragest all;
-	std::array<tile_coveragest,static_cast<size_t>(visual_render_groupst::count)> groups;
-	std::unordered_map<int32_t,uint16_t> selected;
-};
-
 render_coveragest collect_coverage(
 	const std::vector<render_proxyst> &proxies,
 	int32_t dim_y)
@@ -1261,6 +1270,45 @@ render_coveragest collect_coverage(
 		auto &group=coverage.groups[static_cast<size_t>(visual_render_group(proxy.layer))];
 		group.insert(proxy.coverage.begin(),proxy.coverage.end());
 		}
+	return coverage;
+}
+
+std::vector<df::graphic_viewportst *> active_viewports()
+{
+	std::vector<df::graphic_viewportst *> viewports;
+	if(gps==nullptr)return viewports;
+	for(int32_t lower=7;lower>=0;--lower)
+		{
+		df::graphic_viewportst *vp=gps->lower_viewport[lower];
+		if(vp!=nullptr&&vp->flag.bits.active)viewports.push_back(vp);
+		}
+	if(gps->main_viewport!=nullptr&&gps->main_viewport->flag.bits.active)
+		viewports.push_back(gps->main_viewport);
+	return viewports;
+}
+
+std::vector<viewport_renderst> collect_viewport_renders(
+	df::renderer_2d_base *renderer,
+	const std::vector<df::graphic_viewportst *> &viewports)
+{
+	std::vector<viewport_renderst> renders;
+	renders.reserve(viewports.size());
+	for(df::graphic_viewportst *vp:viewports)
+		{
+		viewport_renderst render={vp,collect_proxies(renderer,vp),{}};
+		render.coverage=collect_coverage(render.proxies,vp->dim_y);
+		renders.push_back(std::move(render));
+		}
+	return renders;
+}
+
+render_coveragest collect_viewport_coverage(
+	const std::vector<viewport_renderst> &viewports)
+{
+	render_coveragest coverage;
+	for(const viewport_renderst &viewport:viewports)
+		coverage.all.insert(
+			viewport.coverage.all.begin(),viewport.coverage.all.end());
 	return coverage;
 }
 
@@ -1325,23 +1373,61 @@ void draw_interpolation_stages(
 		}
 }
 
+void redraw_viewport_tiles(
+	df::renderer_2d_base *renderer,
+	const viewport_renderst &viewport,
+	const tile_coveragest &coverage)
+{
+	df::graphic_viewportst *vp=viewport.viewport;
+	for(const auto &[x,y]:coverage)
+		{
+		if(!inside_clip(vp,x,y))continue;
+		redraw_viewport_tile(renderer,viewport,x,y);
+		}
+}
+
+void draw_viewport_interpolation_stages(
+	df::renderer_2d_base *renderer,
+	const std::vector<viewport_renderst> &viewports,
+	const tile_coveragest &coverage)
+{
+	for(size_t index=0;index<viewports.size();++index)
+		{
+		// A lower z-level's proxy must be covered by the next viewport's fog and terrain.
+		// Reapply that viewport before its own proxies, matching DF's lower-to-main draw order.
+		if(index>0)redraw_viewport_tiles(renderer,viewports[index],coverage);
+		const viewport_renderst &viewport=viewports[index];
+		draw_interpolation_stages(
+			renderer,viewport.viewport,viewport.proxies,viewport.coverage);
+		}
+}
+
+bool has_mirrored_viewport_facing(
+	const std::vector<df::graphic_viewportst *> &viewports)
+{
+	for(const df::graphic_viewportst *vp:viewports)
+		if(animation_manager.has_mirrored_facing(vp))return true;
+	return false;
+}
+
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
+	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
 	if(vp!=nullptr)update_visual_context(renderer,vp);
 	const uint32_t now_ms=Core::getInstance().p->getTickCount();
 	animation_manager.begin_frame(now_ms);
-	if(vp!=nullptr)
+	for(df::graphic_viewportst *viewport:viewports)
 		{
-		const auto input=animation_input(vp);
+		const auto input=animation_input(viewport);
 		animation_manager.synchronize_viewport(
 			input,
-			vp->flag.bits.active);
-		if(vp->flag.bits.active&&construction_transitions_enabled)
+			true);
+		}
+	if(vp!=nullptr&&vp->flag.bits.active&&construction_transitions_enabled)
+		{
 			tile_transition_manager.synchronize(vp,now_ms);
-		else
-			tile_transition_manager.clear();
 		}
 	else
 		tile_transition_manager.clear();
@@ -1363,11 +1449,12 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	if(glide)camera_was_offset=true;
 	if(!glide&&!animation_manager.requires_full_redraw()&&
 		!tile_transition_manager.active()&&
-		(!flip_enabled||!animation_manager.has_mirrored_facing(vp)))
+		(!flip_enabled||!has_mirrored_viewport_facing(viewports)))
 		return;
 
-	std::vector<render_proxyst> proxies=collect_proxies(renderer,vp);
-	render_coveragest coverage=collect_coverage(proxies,vp->dim_y);
+	std::vector<viewport_renderst> viewport_renders=
+		collect_viewport_renders(renderer,viewports);
+	render_coveragest coverage=collect_viewport_coverage(viewport_renders);
 	add_tile_transition_coverage(coverage,vp->dim_y);
 
 	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
@@ -1404,10 +1491,11 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		for(int32_t x=vp->clipx[0];x<=vp->clipx[1];++x)
 			{
 			for(int32_t y=vp->clipy[0];y<=vp->clipy[1];++y)
-				redraw_world_tile(renderer,vp,x,y,coverage.selected);
+				redraw_world_tile(renderer,viewport_renders,x,y);
 			}
 		draw_tile_transitions(renderer,vp);
-		draw_interpolation_stages(renderer,vp,proxies,coverage);
+		draw_viewport_interpolation_stages(
+			renderer,viewport_renders,coverage.all);
 		renderer->origin_x=saved_origin_x;
 		renderer->origin_y=saved_origin_y;
 		render_set_clip_rect(sdl_renderer,nullptr);
@@ -1438,10 +1526,10 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	for(const auto &[x,y]:redraw_coverage)
 		{
-		if(inside_clip(vp,x,y))redraw_world_tile(renderer,vp,x,y,coverage.selected);
+		if(inside_clip(vp,x,y))redraw_world_tile(renderer,viewport_renders,x,y);
 		}
 	draw_tile_transitions(renderer,vp);
-	draw_interpolation_stages(renderer,vp,proxies,coverage);
+	draw_viewport_interpolation_stages(renderer,viewport_renders,coverage.all);
 
 	previous_coverage=std::move(coverage.all);
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -6,7 +6,6 @@
 #include "VTableInterpose.h"
 
 #include "modules/DFSDL.h"
-#include "modules/Maps.h"
 
 #include "df/enabler.h"
 #include "df/graphic.h"
@@ -14,7 +13,6 @@
 #include "df/renderer_2d_base.h"
 #include "df/texture_fullid.h"
 
-#include "TileTypes.h"
 #include "visual_animation.h"
 
 #include <SDL_render.h>
@@ -52,10 +50,6 @@ decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
 decltype(&SDL_RenderSetClipRect) render_set_clip_rect=nullptr;
 decltype(&SDL_GetRenderDrawColor) get_render_draw_color=nullptr;
 decltype(&SDL_SetRenderDrawColor) set_render_draw_color=nullptr;
-decltype(&SDL_GetTextureAlphaMod) get_texture_alpha_mod=nullptr;
-decltype(&SDL_SetTextureAlphaMod) set_texture_alpha_mod=nullptr;
-decltype(&SDL_GetTextureBlendMode) get_texture_blend_mode=nullptr;
-decltype(&SDL_SetTextureBlendMode) set_texture_blend_mode=nullptr;
 
 visual_animation_managerst animation_manager;
 std::set<std::pair<int32_t,int32_t>> previous_coverage;
@@ -69,7 +63,6 @@ bool has_view_signature=false;
 int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
-bool construction_transitions_enabled=false;
 bool flip_enabled=false;
 
 // --- free camera -------------------------------------------------------------------------------
@@ -495,183 +488,6 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 		};
 }
 
-struct tile_transitionst
-{
-	tile_transition_layer layer;
-	int32_t previous_texpos;
-	int32_t current_texpos;
-	uint32_t start_time_ms;
-};
-
-bool is_tile_construction_or_destruction(
-	df::tiletype previous,
-	df::tiletype current)
-{
-	if(previous==current)return false;
-	if(tileMaterial(previous)==df::tiletype_material::CONSTRUCTION||
-		tileMaterial(current)==df::tiletype_material::CONSTRUCTION)
-		return true;
-	if(!isGroundMaterial(previous)||
-		tileShape(previous)==tileShape(current))return false;
-	return isWallTerrain(previous)||
-		isFloorTerrain(previous)||
-		isRampTerrain(previous)||
-		isStairTerrain(previous);
-}
-
-class tile_transition_managerst
-{
-	const void *viewport=nullptr;
-	int32_t dim_x=0;
-	int32_t dim_y=0;
-	uint64_t context_revision=0;
-	int32_t pan_x=0;
-	int32_t pan_y=0;
-	bool has_context=false;
-	std::unordered_map<int32_t,tile_transitionst> transitions;
-	std::vector<df::tiletype> previous_tiletypes;
-	std::vector<uint8_t> has_previous_tiletype;
-
-	static constexpr uint32_t transition_duration_ms=120;
-
-	void snapshot_tiletypes(df::graphic_viewportst *vp)
-		{
-		const int32_t tile_count=vp->dim_x*vp->dim_y;
-		previous_tiletypes.resize(tile_count);
-		has_previous_tiletype.assign(tile_count,0);
-		const int32_t map_x=window_x?*window_x:0;
-		const int32_t map_y=window_y?*window_y:0;
-		const int32_t map_z=window_z?*window_z:0;
-		for(int32_t x=0;x<vp->dim_x;++x)
-			{
-			for(int32_t y=0;y<vp->dim_y;++y)
-				{
-				const int32_t index=x*vp->dim_y+y;
-				const df::tiletype *tiletype=
-					Maps::getTileType(map_x+x,map_y+y,map_z);
-				if(tiletype==nullptr)continue;
-				previous_tiletypes[index]=*tiletype;
-				has_previous_tiletype[index]=1;
-				}
-			}
-		}
-
-	public:
-		void clear()
-			{
-			transitions.clear();
-			previous_tiletypes.clear();
-			has_previous_tiletype.clear();
-			has_context=false;
-			}
-
-		void reset()
-			{
-			clear();
-			}
-
-		void synchronize(df::graphic_viewportst *vp,uint32_t now_ms)
-			{
-			const int32_t current_pan_x=window_x?*window_x:0;
-			const int32_t current_pan_y=window_y?*window_y:0;
-			const bool context_changed=!has_context||viewport!=vp||
-				dim_x!=vp->dim_x||dim_y!=vp->dim_y||
-				context_revision!=visual_context_revision||
-				pan_x!=current_pan_x||pan_y!=current_pan_y;
-			viewport=vp;
-			dim_x=vp->dim_x;
-			dim_y=vp->dim_y;
-			context_revision=visual_context_revision;
-			pan_x=current_pan_x;
-			pan_y=current_pan_y;
-			has_context=true;
-			if(context_changed)
-				{
-				transitions.clear();
-				snapshot_tiletypes(vp);
-				return;
-				}
-
-			const int32_t map_x=window_x?*window_x:0;
-			const int32_t map_y=window_y?*window_y:0;
-			const int32_t map_z=window_z?*window_z:0;
-			for(int32_t x=0;x<dim_x;++x)
-				{
-				for(int32_t y=0;y<dim_y;++y)
-					{
-					const int32_t index=x*dim_y+y;
-					const df::tiletype *tiletype=
-						Maps::getTileType(map_x+x,map_y+y,map_z);
-					const bool gameplay_change=tiletype!=nullptr&&
-						has_previous_tiletype[index]&&
-						is_tile_construction_or_destruction(
-							previous_tiletypes[index],*tiletype);
-					if(tiletype!=nullptr)
-						{
-						previous_tiletypes[index]=*tiletype;
-						has_previous_tiletype[index]=1;
-						}
-					else
-						has_previous_tiletype[index]=0;
-					if(!gameplay_change)continue;
-					const auto candidate=select_tile_transition(
-						vp->screentexpos_background[index],
-						vp->screentexpos_background_old[index],
-						vp->screentexpos_building_one[index],
-						vp->screentexpos_building_one_old[index]);
-					if(candidate.layer!=tile_transition_layer::none)
-						{
-						const auto existing=transitions.find(index);
-						if(existing==transitions.end()||
-							existing->second.layer!=candidate.layer||
-							existing->second.previous_texpos!=candidate.previous_texpos||
-							existing->second.current_texpos!=candidate.current_texpos)
-							{
-							transitions[index]={
-								candidate.layer,
-								candidate.previous_texpos,
-								candidate.current_texpos,
-								now_ms
-								};
-							}
-						}
-					}
-				}
-			for(auto it=transitions.begin();it!=transitions.end();)
-				{
-				if(now_ms-it->second.start_time_ms>=transition_duration_ms)
-					it=transitions.erase(it);
-				else
-					++it;
-				}
-			}
-
-		bool active() const
-			{
-			return !transitions.empty();
-			}
-
-		const tile_transitionst *get(int32_t index) const
-			{
-			const auto found=transitions.find(index);
-			return found==transitions.end()?nullptr:&found->second;
-			}
-
-		float progress(const tile_transitionst &transition,uint32_t now_ms) const
-			{
-			return animation_progress(
-				now_ms,transition.start_time_ms,transition_duration_ms);
-			}
-
-		const std::unordered_map<int32_t,tile_transitionst> &entries() const
-			{
-			return transitions;
-			}
-
-};
-
-tile_transition_managerst tile_transition_manager;
-
 int32_t tile_pixel(int32_t tile,int32_t origin,int32_t zoom)
 {
 	return zoom==128?32*tile+origin:(zoom*32*tile)/128+origin;
@@ -837,24 +653,6 @@ void with_upper_suppressed(
 		});
 }
 
-template<typename Callback>
-void with_incoming_tile_suppressed(
-	df::graphic_viewportst *vp,
-	int32_t index,
-	const Callback &callback)
-{
-	const tile_transitionst *transition=tile_transition_manager.get(index);
-	if(transition==nullptr||transition->current_texpos==0)
-		{
-		callback();
-		return;
-		}
-	if(transition->layer==tile_transition_layer::background)
-		with_zeroed_values(callback,vp->screentexpos_background[index]);
-	else
-		with_zeroed_values(callback,vp->screentexpos_building_one[index]);
-}
-
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -864,12 +662,9 @@ void redraw_viewport_tile(
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
 	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
-	with_incoming_tile_suppressed(vp,index,[&]
-		{
-		with_suppressed_visual_layers(
-			visual_layers(vp),index,
-			selected_mask(viewport.coverage.selected,index),redraw);
-		});
+	with_suppressed_visual_layers(
+		visual_layers(vp),index,
+		selected_mask(viewport.coverage.selected,index),redraw);
 }
 
 void redraw_world_tile(
@@ -937,14 +732,6 @@ SDL_Texture *cached_texture(
 		static_cast<SDL_Texture *>(texture->second);
 }
 
-SDL_Texture *cached_tile_texture(
-	df::renderer_2d_base *renderer,
-	int32_t texpos)
-{
-	SDL_Texture *texture=cached_texture(renderer,texpos,false);
-	return texture!=nullptr?texture:cached_texture(renderer,texpos);
-}
-
 // The render_copy_ex_f null check is defensive only, not a graceful-degradation path.
 // `bind` aborts load_sdl on any missing symbol and plugin_enable then refuses the render hook.
 void render_copy_maybe_mirrored(
@@ -961,29 +748,6 @@ void render_copy_maybe_mirrored(
 		return;
 		}
 	render_copy_f(renderer,texture,nullptr,&destination);
-}
-
-void draw_texture_with_alpha(
-	SDL_Renderer *renderer,
-	SDL_Texture *texture,
-	const SDL_FRect &destination,
-	float opacity,
-	bool mirrored)
-{
-	if(opacity<=0.0f)return;
-	Uint8 saved_alpha=255;
-	SDL_BlendMode saved_blend=SDL_BLENDMODE_NONE;
-	if(get_texture_alpha_mod(texture,&saved_alpha)!=0||
-		get_texture_blend_mode(texture,&saved_blend)!=0)
-		{
-		render_copy_maybe_mirrored(renderer,texture,destination,mirrored);
-		return;
-		}
-	set_texture_blend_mode(texture,SDL_BLENDMODE_BLEND);
-	set_texture_alpha_mod(texture,Uint8(std::lround(saved_alpha*opacity)));
-	render_copy_maybe_mirrored(renderer,texture,destination,mirrored);
-	set_texture_alpha_mod(texture,saved_alpha);
-	set_texture_blend_mode(texture,saved_blend);
 }
 
 void draw_proxy(df::renderer_2d_base *renderer,const render_proxyst &proxy)
@@ -1312,50 +1076,6 @@ render_coveragest collect_viewport_coverage(
 	return coverage;
 }
 
-void add_tile_transition_coverage(
-	render_coveragest &coverage,
-	int32_t dim_y)
-{
-	for(const auto &entry:tile_transition_manager.entries())
-		coverage.all.emplace(entry.first/dim_y,entry.first%dim_y);
-}
-
-void draw_tile_transitions(
-	df::renderer_2d_base *renderer,
-	df::graphic_viewportst *vp)
-{
-	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
-	const int32_t zoom=renderer->viewport_zoom_factor;
-	const int32_t tile_size=zoom==128?32:std::max(1,zoom*32/128);
-	const uint32_t now_ms=animation_manager.get_frame_time_ms();
-	for(const auto &[index,transition]:tile_transition_manager.entries())
-		{
-		const int32_t x=index/vp->dim_y;
-		const int32_t y=index%vp->dim_y;
-		if(!inside_clip(vp,x,y))continue;
-		const int32_t target_x=tile_pixel(x,renderer->origin_x,zoom);
-		const int32_t target_y=tile_pixel(y,renderer->origin_y,zoom);
-		const float progress=tile_transition_manager.progress(transition,now_ms);
-		const SDL_FRect destination=
-			{
-			float(target_x),
-			float(target_y),
-			float(tile_size),
-			float(tile_size)
-			};
-		SDL_Texture *previous=cached_tile_texture(renderer,transition.previous_texpos);
-		SDL_Texture *current=cached_tile_texture(renderer,transition.current_texpos);
-		if(previous==nullptr&&current==nullptr)
-			{
-			continue;
-			}
-		if(previous!=nullptr)
-			draw_texture_with_alpha(sdl_renderer,previous,destination,1.0f-progress,false);
-		if(current!=nullptr)
-			draw_texture_with_alpha(sdl_renderer,current,destination,progress,false);
-		}
-}
-
 void draw_interpolation_stages(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
@@ -1425,12 +1145,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 			input,
 			true);
 		}
-	if(vp!=nullptr&&vp->flag.bits.active&&construction_transitions_enabled)
-		{
-			tile_transition_manager.synchronize(vp,now_ms);
-		}
-	else
-		tile_transition_manager.clear();
 	animation_manager.end_frame();
 
 	if(vp==nullptr||!vp->flag.bits.active||renderer->sdl_renderer==nullptr)
@@ -1448,14 +1162,12 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		}
 	if(glide)camera_was_offset=true;
 	if(!glide&&!animation_manager.requires_full_redraw()&&
-		!tile_transition_manager.active()&&
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports)))
 		return;
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
 	render_coveragest coverage=collect_viewport_coverage(viewport_renders);
-	add_tile_transition_coverage(coverage,vp->dim_y);
 
 	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
 	const int32_t zoom=renderer->viewport_zoom_factor;
@@ -1493,7 +1205,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 			for(int32_t y=vp->clipy[0];y<=vp->clipy[1];++y)
 				redraw_world_tile(renderer,viewport_renders,x,y);
 			}
-		draw_tile_transitions(renderer,vp);
 		draw_viewport_interpolation_stages(
 			renderer,viewport_renders,coverage.all);
 		renderer->origin_x=saved_origin_x;
@@ -1528,7 +1239,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		{
 		if(inside_clip(vp,x,y))redraw_world_tile(renderer,viewport_renders,x,y);
 		}
-	draw_tile_transitions(renderer,vp);
 	draw_viewport_interpolation_stages(renderer,viewport_renders,coverage.all);
 
 	previous_coverage=std::move(coverage.all);
@@ -1557,10 +1267,6 @@ void clear_sdl_bindings()
 	render_set_clip_rect=nullptr;
 	get_render_draw_color=nullptr;
 	set_render_draw_color=nullptr;
-	get_texture_alpha_mod=nullptr;
-	set_texture_alpha_mod=nullptr;
-	get_texture_blend_mode=nullptr;
-	set_texture_blend_mode=nullptr;
 }
 
 bool load_sdl(color_ostream &out)
@@ -1580,10 +1286,6 @@ bool load_sdl(color_ostream &out)
 	bind(SDL_RenderSetClipRect,render_set_clip_rect);
 	bind(SDL_GetRenderDrawColor,get_render_draw_color);
 	bind(SDL_SetRenderDrawColor,set_render_draw_color);
-	bind(SDL_GetTextureAlphaMod,get_texture_alpha_mod);
-	bind(SDL_SetTextureAlphaMod,set_texture_alpha_mod);
-	bind(SDL_GetTextureBlendMode,get_texture_blend_mode);
-	bind(SDL_SetTextureBlendMode,set_texture_blend_mode);
 	#undef bind
 	return true;
 }
@@ -1591,7 +1293,6 @@ bool load_sdl(color_ostream &out)
 void reset_state()
 {
 	animation_manager=visual_animation_managerst();
-	tile_transition_manager.reset();
 	previous_coverage.clear();
 	visual_context_revision=0;
 	previous_viewport=nullptr;
@@ -1606,7 +1307,6 @@ void reset_state()
 	camera_enabled=false;
 	camera_has_prev=false;
 	camera_was_offset=false;
-	construction_transitions_enabled=false;
 	flip_enabled=false;
 }
 
@@ -1622,32 +1322,9 @@ command_result status_command(
 			is_enabled?"enabled":"disabled");
 		out.print("free camera: {}, offset {:.3f} {:.3f} (tiles east/south of the grid)\n",
 			camera_enabled?"on":"off",-rest_x,-rest_y);
-		out.print("construction transitions: {}\n",
-			construction_transitions_enabled?"on":"off");
 		out.print("sprite flipping: {}\n",
 			flip_enabled?"on":"off");
 		return CR_OK;
-		}
-	if(parameters[0]=="construction")
-		{
-		if(parameters.size()==1)
-			{
-			out.print("construction transitions: {}\n",
-				construction_transitions_enabled?"on":"off");
-			return CR_OK;
-			}
-		if(parameters.size()==2&&parameters[1]=="on")
-			{
-			construction_transitions_enabled=true;
-			return CR_OK;
-			}
-		if(parameters.size()==2&&parameters[1]=="off")
-			{
-			construction_transitions_enabled=false;
-			tile_transition_manager.clear();
-			return CR_OK;
-			}
-		return CR_WRONG_USAGE;
 		}
 	if(parameters[0]=="camera")
 		{

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -193,6 +193,33 @@ int main()
 	assert(manager.get_facing(viewport,dim,0)==native_sprite_facing);
 	assert(manager.get_facing(nullptr,0,0)==native_sprite_facing);
 	}
+
+	// Each rendered z-level has its own viewport buffers; tracking one must not suppress another.
+	{
+	const int lower_token=0;
+	const int main_token=0;
+	const void *lower_viewport=&lower_token;
+	const void *main_viewport=&main_token;
+	visual_animation_managerst z_levels;
+	auto lower_input=make_input(lower_viewport,dim,empty);
+	auto main_input=make_input(main_viewport,dim,empty);
+	set_layer(lower_input,viewport_visual_layer::center,before,empty);
+	set_layer(main_input,viewport_visual_layer::center,before,empty);
+	z_levels.begin_frame(1000);
+	z_levels.synchronize_viewport(lower_input,true);
+	z_levels.synchronize_viewport(main_input,true);
+	z_levels.end_frame();
+	set_layer(lower_input,viewport_visual_layer::center,west_after,before);
+	set_layer(main_input,viewport_visual_layer::center,west_after,before);
+	z_levels.begin_frame(1016);
+	z_levels.synchronize_viewport(lower_input,true);
+	z_levels.synchronize_viewport(main_input,true);
+	z_levels.end_frame();
+	assert(z_levels.get_movement(
+		lower_viewport,viewport_visual_layer::center,1,2).active);
+	assert(z_levels.get_movement(
+		main_viewport,viewport_visual_layer::center,1,2).active);
+	}
 	}
 
 	// All four diagonals through the manager, so every step carries a real dy as well as a dx.
@@ -251,11 +278,15 @@ int main()
 	int32_t pan_empty[pan_dim*pan_dim]={};
 	int32_t at_one[pan_dim*pan_dim]={};
 	int32_t at_two[pan_dim*pan_dim]={};
+	int32_t unmatched_a[pan_dim*pan_dim]={};
+	int32_t unmatched_b[pan_dim*pan_dim]={};
 	const int pan_token=0;
 	const void *pan_viewport=&pan_token;
 
 	at_one[1*pan_dim+1]=77;
 	at_two[2*pan_dim+1]=77;   // steps east, x 1 -> 2, so it faces east
+	unmatched_a[2*pan_dim+1]=78;
+	unmatched_b[2*pan_dim+1]=79;
 
 	// LANDED: the shift is recognized, so facing follows the buffers.
 	{
@@ -294,18 +325,20 @@ int main()
 	run_frame(abandoned,input,2016);
 	assert(abandoned.get_facing(pan_viewport,2,1)==visual_facingst::east);
 
-	// The buffers stay put, so the majority-match test fails every frame.
+	// Changed buffers keep the failed majority-match test running every frame.
 	// It tolerates four before giving up on the fifth.
 	input.pan_x=1;
-	set_layer(input,viewport_visual_layer::center,at_two,at_two);
 	for(int32_t frame=0;frame<4;++frame)
 		{
+		set_layer(input,viewport_visual_layer::center,at_two,
+			frame%2==0?unmatched_a:unmatched_b);
 		run_frame(abandoned,input,2032+uint32_t(frame)*16);
 		// Still pending, so the facing survives.
 		// The assertion after the giving-up frame therefore tests the reset, not an empty grid.
 		assert(abandoned.get_facing(pan_viewport,2,1)==visual_facingst::east);
 		assert(abandoned.has_mirrored_facing(pan_viewport));
 		}
+	set_layer(input,viewport_visual_layer::center,at_two,unmatched_a);
 	run_frame(abandoned,input,2096);
 	assert(abandoned.get_facing(pan_viewport,2,1)==native_sprite_facing);
 	assert(!abandoned.has_mirrored_facing(pan_viewport));

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -68,19 +68,6 @@ int main()
 	rollover.begin_frame(std::numeric_limits<uint32_t>::max()-5);
 	rollover.begin_frame(3);
 	assert(rollover.get_frame_delta_ms()==9);
-	assert(select_tile_transition(10,9,20,19).layer==
-		tile_transition_layer::building_one);
-	assert(select_tile_transition(10,9,20,19).previous_texpos==19);
-	assert(select_tile_transition(10,9,20,19).current_texpos==20);
-	const auto mined=select_tile_transition(10,9,0,20);
-	assert(mined.layer==tile_transition_layer::building_one);
-	assert(mined.previous_texpos==20&&mined.current_texpos==0);
-	const auto dug=select_tile_transition(0,10,0,0);
-	assert(dug.layer==tile_transition_layer::background);
-	assert(dug.previous_texpos==10&&dug.current_texpos==0);
-	assert(select_tile_transition(10,10,20,20).layer==
-		tile_transition_layer::none);
-
 	// Facing rule: only a horizontal component changes facing.
 	assert(facing_after_move(1,visual_facingst::west)==visual_facingst::east);
 	assert(facing_after_move(-1,visual_facingst::east)==visual_facingst::west);

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -156,41 +156,6 @@ struct visual_movement_renderst
 	bool inherited=false;
 };
 
-enum class tile_transition_layer : uint8_t
-{
-	none,
-	background,
-	building_one
-};
-
-struct tile_transition_candidatest
-{
-	tile_transition_layer layer=tile_transition_layer::none;
-	int32_t previous_texpos=0;
-	int32_t current_texpos=0;
-};
-
-inline tile_transition_candidatest select_tile_transition(
-	int32_t current_background,
-	int32_t previous_background,
-	int32_t current_building_one,
-	int32_t previous_building_one)
-{
-	if(current_building_one!=previous_building_one)
-		return {
-			tile_transition_layer::building_one,
-			previous_building_one,
-			current_building_one
-			};
-	if(current_background!=previous_background)
-		return {
-			tile_transition_layer::background,
-			previous_background,
-			current_background
-			};
-	return {};
-}
-
 inline float animation_progress(
 	uint32_t now_ms,
 	uint32_t start_time_ms,


### PR DESCRIPTION
## Summary
- animate active lower z-level viewports independently
- share the per-viewport redraw suppression path
- correct the pending-scroll regression test to use advancing buffers

## Test
- rtk g++ -std=c++17 -Wall -Wextra -pedantic test_visual_animation_manager.cpp -o /tmp/smooth-movement-test-review
- rtk /tmp/smooth-movement-test-review