### PR TITLE
Fix middle-drag stutter and gate lower z-level animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 
 # internal script
 /build-install.sh
+/build-upload.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Animate visible lower z-levels only when enabled with `smooth-movement zlevels on`.
 - Mirror creature sprites horizontally so they face their direction of travel.
   Dwarf Fortress creature art natively faces west, so only creatures moving
   east are mirrored. Facing is sticky: only horizontal movement changes it,

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A visual plugin for Dwarf Fortress that makes movement smoother.
 - **Animated carts:** wheelbarrows and minecarts move smoothly too.
 - **Sprites flip** creatures can optionally face the direction they are walking.
 - **Free camera:** the camera can optionally glide and be dragged with the mouse (WIP).
+- **Lower z-levels:** their animation is optional and off by default.
 
 ## Installation
 
@@ -31,6 +32,7 @@ smooth-movement             # show plugin status
 disable smooth-movement     # disable the plugin
 smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
+smooth-movement zlevels on  # animate visible lower z-levels
 ```
 
 ## Compatibility

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -41,7 +41,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.3.0";
+constexpr const char *plugin_version="0.4.2";
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -64,6 +64,9 @@ int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
 bool flip_enabled=false;
+bool lower_z_levels_enabled=false;
+bool previous_middle_mouse=false;
+bool has_middle_mouse=false;
 
 // --- free camera -------------------------------------------------------------------------------
 // The camera is visually unbound from the tile grid. Two layered offsets:
@@ -473,7 +476,9 @@ auto visual_layers(Viewport *vp,bool previous=false)
 	return layers;
 }
 
-viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
+viewport_visual_animation_inputst animation_input(
+	df::graphic_viewportst *vp,
+	bool pan_finished=false)
 {
 	const df::graphic_viewportst *const_viewport=vp;
 	return {
@@ -484,7 +489,8 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 		visual_layers(const_viewport),
 		visual_layers(const_viewport,true),
 		window_x?*window_x:0,
-		window_y?*window_y:0
+		window_y?*window_y:0,
+		pan_finished
 		};
 }
 
@@ -1127,11 +1133,12 @@ std::vector<df::graphic_viewportst *> active_viewports()
 {
 	std::vector<df::graphic_viewportst *> viewports;
 	if(gps==nullptr)return viewports;
-	for(int32_t lower=7;lower>=0;--lower)
-		{
-		df::graphic_viewportst *vp=gps->lower_viewport[lower];
-		if(viewport_readable(vp))viewports.push_back(vp);
-		}
+	if(lower_z_levels_enabled)
+		for(int32_t lower=7;lower>=0;--lower)
+			{
+			df::graphic_viewportst *vp=gps->lower_viewport[lower];
+			if(viewport_readable(vp))viewports.push_back(vp);
+			}
 	if(viewport_readable(gps->main_viewport))
 		viewports.push_back(gps->main_viewport);
 	return viewports;
@@ -1227,12 +1234,16 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
+	const bool middle_mouse=enabler!=nullptr&&enabler->mouse_mbut;
+	const bool pan_finished=has_middle_mouse&&previous_middle_mouse&&!middle_mouse;
+	previous_middle_mouse=middle_mouse;
+	has_middle_mouse=true;
 
 	if(vp!=nullptr)update_visual_context(renderer,vp);
 	const uint32_t now_ms=Core::getInstance().p->getTickCount();
 	animation_manager.begin_frame(now_ms);
 	for(df::graphic_viewportst *viewport:viewports)
-		animation_manager.synchronize_viewport(animation_input(viewport));
+		animation_manager.synchronize_viewport(animation_input(viewport,pan_finished));
 	animation_manager.end_frame();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
@@ -1396,6 +1407,9 @@ void reset_state()
 	camera_has_prev=false;
 	camera_was_offset=false;
 	flip_enabled=false;
+	lower_z_levels_enabled=false;
+	previous_middle_mouse=false;
+	has_middle_mouse=false;
 }
 
 command_result status_command(
@@ -1412,6 +1426,8 @@ command_result status_command(
 			camera_enabled?"on":"off",-rest_x,-rest_y);
 		out.print("sprite flipping: {}\n",
 			flip_enabled?"on":"off");
+		out.print("lower z-level animation: {}\n",
+			lower_z_levels_enabled?"on":"off");
 		return CR_OK;
 		}
 	if(parameters[0]=="camera")
@@ -1491,6 +1507,24 @@ command_result status_command(
 			}
 		return CR_WRONG_USAGE;
 		}
+	if(parameters[0]=="zlevels")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("lower z-level animation: {}\n",
+				lower_z_levels_enabled?"on":"off");
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			lower_z_levels_enabled=parameters[1]=="on";
+			if(gps!=nullptr)++gps->force_full_display_count;
+			out.print("smooth-movement: lower z-level animation {}\n",parameters[1]);
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
+		}
 	return CR_WRONG_USAGE;
 }
 
@@ -1502,7 +1536,7 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 	commands.emplace_back(
 		"smooth-movement",
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
-		"sprite flipping: flip on|off.",
+		"sprite flipping: flip on|off; lower z-levels: zlevels on|off.",
 		status_command);
 	return CR_OK;
 }

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -607,6 +607,35 @@ int main()
 	run_frame(reset_on_zoom,pan_input,8020);
 	assert(!reset_on_zoom.get_movement(viewport,viewport_visual_layer::center,1,1).active);
 
+	// Releasing a drag abandons a pan that never landed instead of waiting 120 redraws.
+	// The first changed buffer stays guarded in case it is the late pan; the next move resumes.
+	visual_animation_managerst released_drag;
+	pan_current.fill(0);
+	pan_previous.fill(0);
+	pan_input.pan_x=0;
+	pan_input.pan_finished=false;
+	pan_input.context_revision=1;
+	pan_current[1*3+1]=42;
+	pan_previous=pan_current;
+	run_frame(released_drag,pan_input,8100);
+	pan_input.pan_x=1;
+	run_frame(released_drag,pan_input,8110);
+	pan_input.pan_finished=true;
+	run_frame(released_drag,pan_input,8120);
+	pan_input.pan_finished=false;
+	pan_previous=pan_current;
+	pan_current[2*3+1]=42;
+	pan_current[1*3+1]=0;
+	run_frame(released_drag,pan_input,8130);
+	assert(!released_drag.get_movement(
+		viewport,viewport_visual_layer::center,2,1).active);
+	pan_previous=pan_current;
+	pan_current[1*3+1]=42;
+	pan_current[2*3+1]=0;
+	run_frame(released_drag,pan_input,8140);
+	assert(released_drag.get_movement(
+		viewport,viewport_visual_layer::center,1,1).active);
+
 	// Status fragments inherit nearby center motion even while their texture flashes.
 	std::array<int32_t,9> status_current{};
 	std::array<int32_t,9> status_previous{};

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -135,6 +135,7 @@ struct viewport_visual_animation_inputst
 	// Only a hint: it changes at input time, the buffers shift on a later render frame.
 	int32_t pan_x=0;
 	int32_t pan_y=0;
+	bool pan_finished=false;
 
 	bool valid() const
 		{
@@ -604,6 +605,13 @@ class visual_animation_managerst
 					// It may yet land, so do not resume detection on the very next redraw.
 					state.suppress_frames=2;
 					}
+				}
+			if(input.pan_finished&&!state.pending.empty())
+				{
+				// A released drag cannot provide more evidence for an unlanded pan.
+				abandon_pending(state);
+				reset_facing(state);
+				state.suppress_frames=1;
 				}
 
 			const bool suppress=!buffers_advanced||crossed_views||


### PR DESCRIPTION
## Summary
- stop an unresolved pan queue from suppressing movement after middle-mouse release
- keep the first changed buffer guarded against a late viewport shift
- make lower z-level animation opt-in with `smooth-movement zlevels on`
- document the new option and add regression coverage

## Regression
The stutter was introduced by d78a2de when outstanding map scrolls became a queue with a 120-redraw timeout. This keeps the reversing-drag protection from that change while clearing an unresolved queue when the drag ends.

## Validation
- `smooth-movement-test`
- Windows plugin build against DFHack 53.16-r1