### PR TITLE
Add optional linear movement easing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Add an optional linear movement easing mode (`smooth-movement easing linear`),
+  alongside the existing smoothstep curve which stays the default. Smoothstep
+  has zero velocity at both ends of every tile-to-tile hop, so a unit moving
+  every tick visibly stops and restarts at each tile; linear holds constant
+  velocity across the hop instead. Corners still turn sharply either way --
+  this only removes the per-tile dead-stop. Switch back with
+  `smooth-movement easing smoothstep`.
 - Mirror creature sprites horizontally so they face their direction of travel.
   Dwarf Fortress creature art natively faces west, so only creatures moving
   east are mirrored. Facing is sticky: only horizontal movement changes it,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,21 @@ smooth-movement             # show plugin status
 disable smooth-movement     # disable the plugin
 smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
+smooth-movement easing linear   # constant-velocity movement (see below)
 ```
+
+### Movement easing
+
+Each tile-to-tile move is tweened over a fixed duration. By default it uses a
+smoothstep curve, which eases in and out -- zero velocity at both the start
+and end of every hop. For a unit moving every tick this reads as a rhythmic
+stutter: accelerate, arrive, stop, repeat.
+
+`smooth-movement easing linear` switches to constant velocity across each
+hop instead, so continuously moving units glide rather than stutter. It does
+not smooth out the sharp turn at corners (that would need velocity carried
+across hops, which this plugin doesn't do), only the dead-stop at each tile.
+Switch back with `smooth-movement easing smoothstep`, the default.
 
 ## Compatibility
 

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1412,6 +1412,9 @@ command_result status_command(
 			camera_enabled?"on":"off",-rest_x,-rest_y);
 		out.print("sprite flipping: {}\n",
 			flip_enabled?"on":"off");
+		out.print("movement easing: {}\n",
+			animation_manager.get_easing_mode()==easing_modest::linear?
+				"linear":"smoothstep");
 		return CR_OK;
 		}
 	if(parameters[0]=="camera")
@@ -1491,6 +1494,32 @@ command_result status_command(
 			}
 		return CR_WRONG_USAGE;
 		}
+	if(parameters[0]=="easing")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("movement easing: {}\n",
+				animation_manager.get_easing_mode()==easing_modest::linear?
+					"linear":"smoothstep");
+			return CR_OK;
+			}
+		// Smoothstep decelerates to a dead stop at every tile before the next hop starts;
+		// linear holds constant velocity across the hop instead. Corners still turn sharply
+		// either way -- only the per-tile stop-start is what this switches.
+		if(parameters.size()==2&&parameters[1]=="smoothstep")
+			{
+			animation_manager.set_easing_mode(easing_modest::smoothstep);
+			out.print("smooth-movement: movement easing set to smoothstep\n");
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="linear")
+			{
+			animation_manager.set_easing_mode(easing_modest::linear);
+			out.print("smooth-movement: movement easing set to linear\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
+		}
 	return CR_WRONG_USAGE;
 }
 
@@ -1502,7 +1531,7 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 	commands.emplace_back(
 		"smooth-movement",
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
-		"sprite flipping: flip on|off.",
+		"sprite flipping: flip on|off; movement easing: easing smoothstep|linear.",
 		status_command);
 	return CR_OK;
 }

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -414,6 +414,10 @@ int main()
 	}
 
 	assert(animation_progress(100,0,100)==1.0f);
+	// Default mode is smoothstep: eases in, so it lags plain linear progress early in the hop.
+	assert(animation_progress(25,0,100)==animation_progress(25,0,100,easing_modest::smoothstep));
+	assert(animation_progress(25,0,100)<0.25f);
+	assert(animation_progress(25,0,100,easing_modest::linear)==0.25f);
 	assert(inherited_visual_source_tile(0,0,1)==-1);
 	assert(inherited_visual_source_tile(2,0,1)==1);
 	assert(visual_layer_descriptor(viewport_visual_layer::right).center_x==-1);
@@ -721,4 +725,24 @@ int main()
 		viewport,viewport_visual_layer::vehicle,2,1);
 	assert(chained.active&&chained.source_x>0.0f&&chained.source_x<1.0f&&
 		chained.progress==0.0f);
+
+	// A manager defaults to smoothstep; switching to linear changes reported progress mid-hop.
+	current.fill(0);
+	previous.fill(0);
+	input.current.fill(empty.data());
+	input.previous.fill(empty.data());
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
+	visual_animation_managerst eased;
+	assert(eased.get_easing_mode()==easing_modest::smoothstep);
+	eased.set_easing_mode(easing_modest::linear);
+	assert(eased.get_easing_mode()==easing_modest::linear);
+	run_frame(eased,input,990);
+	previous[0*3+1]=77;
+	current[1*3+1]=77;
+	run_frame(eased,input,1000);
+	previous=current;
+	run_frame(eased,input,1025);
+	const auto eased_move=eased.get_movement(
+		viewport,viewport_visual_layer::center,1,1);
+	assert(eased_move.active&&eased_move.progress==0.25f);
 }

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -156,13 +156,24 @@ struct visual_movement_renderst
 	bool inherited=false;
 };
 
+// smoothstep: zero velocity at both ends of every tile-to-tile hop -- the default, matching
+// upstream behavior. linear: constant velocity across the hop, removing the dead-stop for units
+// moving every tick (corners still have a sharp direction change either way).
+enum class easing_modest : int8_t
+{
+	smoothstep=0,
+	linear=1
+};
+
 inline float animation_progress(
 	uint32_t now_ms,
 	uint32_t start_time_ms,
-	uint32_t duration_ms)
+	uint32_t duration_ms,
+	easing_modest mode=easing_modest::smoothstep)
 {
 	const float linear=std::min(
 		1.0f,float(now_ms-start_time_ms)/duration_ms);
+	if(mode==easing_modest::linear)return linear;
 	return linear*linear*(3.0f-2.0f*linear);
 }
 
@@ -262,6 +273,10 @@ class visual_animation_managerst
 	std::vector<viewport_animationst> viewports;
 
 	static constexpr uint32_t movement_duration_ms=100;
+	// Session setting, not persisted across an enable/disable cycle -- same convention as
+	// smooth-movement.cpp's flip_enabled/camera_enabled globals. Defaults to smoothstep so
+	// reconstructing the manager (plugin re-enable) restores upstream behavior.
+	easing_modest easing_mode=easing_modest::smoothstep;
 	// Scrolling faster than detection keeps up: give up rather than test ever more prefixes.
 	static constexpr size_t max_pending_shifts=8;
 	// Bounds the wait on a scroll that never lands, so suppression cannot stick forever.
@@ -408,11 +423,21 @@ class visual_animation_managerst
 	float movement_progress(uint32_t start_time_ms) const
 		{
 		return animation_progress(
-			frame_time_ms,start_time_ms,movement_duration_ms);
+			frame_time_ms,start_time_ms,movement_duration_ms,easing_mode);
 		}
 
 	public:
 		visual_animation_managerst()=default;
+
+		void set_easing_mode(easing_modest mode)
+			{
+			easing_mode=mode;
+			}
+
+		easing_modest get_easing_mode() const
+			{
+			return easing_mode;
+			}
 
 		void begin_frame(uint32_t now_ms)
 			{


### PR DESCRIPTION
## Problem

Every tile-to-tile movement tween uses a fixed 100ms smoothstep curve
(`animation_progress` in `visual_animation.h`). Smoothstep has zero velocity
at both endpoints by construction, so a unit moving every tick independently
accelerates from a dead stop and decelerates back to one on *every single
tile hop* before the next hop starts. That reads as a rhythmic stutter
(accelerate -> arrive -> stop -> repeat) instead of continuous motion.

The 100ms duration is a fixed constant (`movement_duration_ms`), not derived
from the unit's actual movement speed or ticks-per-tile.

## Fix

Adds an opt-in linear easing mode as an alternative to smoothstep, selected
at runtime through the existing `smooth-movement` command family (same
pattern as `camera on|off` and `flip on|off`):

```text
smooth-movement easing linear       # constant velocity across each hop
smooth-movement easing smoothstep   # back to the default
smooth-movement easing              # show the current mode
smooth-movement                     # status output now also reports it
```

Default behavior is unchanged -- smoothstep stays the default, so nothing
changes for existing users unless they opt in.

`animation_progress()` now takes an `easing_modest` mode (defaulting to
`smoothstep`) and returns plain linear progress when asked, instead of
applying the smoothstep curve to it. That's the single choke point every
rendered tween position already goes through, so it's the only place that
needed to change. The mode itself lives on `visual_animation_managerst`
(needed there since `movement_progress()`/`get_movement()` call
`animation_progress()` internally) and resets to `smoothstep` whenever the
manager is reconstructed on plugin enable/disable -- the same session-only
lifetime `flip_enabled`/`camera_enabled` already have, so this doesn't
introduce a new persistence mechanism.

Linear per-segment motion does not fix the sharp direction change at
corners -- that would need velocity carried across hops (spring/exponential
smoothing), which is intentionally out of scope for this patch.

Also updates `CHANGELOG.md` and the README's command list with a short
"Movement easing" section explaining what linear vs. smoothstep feels like.

## Testing

- The standalone `smooth-movement-test` target (`test_visual_animation_manager.cpp`,
  no DFHack dependency) builds clean with MSVC 19.51 (`/std:c++17 /W4`, only
  pre-existing warnings) and passes, including new assertions that:
  - `animation_progress` returns different values for smoothstep vs. linear
    partway through a hop, and the default matches the explicit smoothstep call.
  - a `visual_animation_managerst` defaults to `easing_modest::smoothstep`,
    and switching to `linear` changes the progress reported by `get_movement()`
    mid-hop.
- **Not build-tested against the actual DFHack SDK/plugin target** -- this
  sandbox has no DFHack headers (`Core.h`, `PluginManager.h`, `df/*`, etc.)
  or `dfhack_plugin()` CMake macro available, so `smooth-movement.cpp` itself
  (as opposed to the header-only test target) could not be compiled here.
  I checked types/includes/signatures by hand (the new code only touches
  `status_command`'s existing parameter-dispatch pattern and calls
  `animation_manager.set_easing_mode()`/`get_easing_mode()`, both new public
  methods with no DFHack-side dependencies), but a real DFHack toolchain
  build should be confirmed before merging.

## Note on related work

I checked open issues/PRs first: #13 also touches this exact function and
unconditionally replaces smoothstep with linear (no toggle, default changes
for everyone) as one part of a much larger bundled change (FPS-scaled
duration, per-visual cadence estimation, camera/deadlock fixes, etc.). This
PR is a separate, narrowly-scoped alternative -- opt-in, default unchanged,
touching only the easing curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
