### PR TITLE
Prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
+  stage and engine tile repaints, and (while on) times the render hook split into movement
+  detection and drawing. Timing is off by default; counting costs one increment per frame,
+  per painted frame and per engine repaint.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Set smoothstep movement tweens to 150 ms. Add optional linear easing with
+  adaptive 150–500 ms durations based on the cadence between consecutive steps
+  (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units
+  (`smooth-movement hauled on`). Both flags are off by default.
 - Mirror creature sprites horizontally so they face their direction of travel.
   Dwarf Fortress creature art natively faces west, so only creatures moving
   east are mirrored. Facing is sticky: only horizontal movement changes it,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A visual plugin for Dwarf Fortress that makes movement smoother.
 
 ## Features
 
-- **Smooth movement:** creatures, hauled items, and vehicles glide between tiles.
+- **Smooth movement:** creatures, hauled raw materials, and vehicles glide between tiles.
 - **Synced icons:** status icons follow their creature while it moves.
 - **Animated carts:** wheelbarrows and minecarts move smoothly too.
 - **Sprites flip** creatures can optionally face the direction they are walking.
@@ -29,8 +29,12 @@ enable smooth-movement
 ```text
 smooth-movement             # show plugin status
 disable smooth-movement     # disable the plugin
+smooth-movement all on      # enable every flag except the WIP free camera
+smooth-movement all off     # disable every flag except the WIP free camera
 smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
+smooth-movement linear on   # use linear easing with adaptive 150–500 ms movement tweens
+smooth-movement hauled on   # show icons for carried boulders, bars, and wood
 ```
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A visual plugin for Dwarf Fortress that makes movement smoother.
 - **Animated carts:** wheelbarrows and minecarts move smoothly too.
 - **Sprites flip** creatures can optionally face the direction they are walking.
 - **Free camera:** the camera can optionally glide and be dragged with the mouse (WIP).
+- **Smooth native follow:** Dwarf Fortress's unit follow glides automatically, even with the free camera off.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ A visual plugin for Dwarf Fortress that makes movement smoother.
 ## Features
 
 - **Smooth movement:** creatures, hauled raw materials, and vehicles glide between tiles.
-- **Synced icons:** status icons follow their creature while it moves.
-- **Animated carts:** wheelbarrows and minecarts move smoothly too.
 - **Sprites flip** creatures can optionally face the direction they are walking.
+- **Smooth native follow:** Dwarf Fortress's unit follow glides automatically.
 - **Free camera:** the camera can optionally glide and be dragged with the mouse (WIP).
-- **Smooth native follow:** Dwarf Fortress's unit follow glides automatically, even with the free camera off.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ enable smooth-movement
 ```text
 smooth-movement             # show plugin status
 disable smooth-movement     # disable the plugin
-smooth-movement all on      # enable every flag except the WIP free camera
-smooth-movement all off     # disable every flag except the WIP free camera
+smooth-movement all on      # enable flip, linear and hauled (not the WIP free camera or stats)
+smooth-movement all off     # disable flip, linear and hauled
 smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
 smooth-movement linear on   # use linear easing with adaptive 150–500 ms movement tweens
 smooth-movement hauled on   # show icons for carried boulders, bars, and wood
+smooth-movement stats on    # time the render hook; `smooth-movement stats` prints the numbers
 ```
 
 ## Compatibility

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -6,12 +6,20 @@
 #include "VTableInterpose.h"
 
 #include "modules/DFSDL.h"
+#include "modules/Materials.h"
+#include "modules/Units.h"
 
 #include "df/enabler.h"
 #include "df/graphic.h"
 #include "df/graphic_viewportst.h"
+#include "df/item.h"
+#include "df/item_type.h"
+#include "df/material.h"
 #include "df/renderer_2d_base.h"
 #include "df/texture_fullid.h"
+#include "df/unit.h"
+#include "df/unit_inventory_item.h"
+#include "df/viewport_spatter_flag.h"
 
 #include "visual_animation.h"
 
@@ -41,7 +49,7 @@ REQUIRE_GLOBAL(window_z);
 
 namespace {
 
-constexpr const char *plugin_version="0.3.0";
+constexpr const char *plugin_version="0.5.0";
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -64,6 +72,7 @@ int32_t previous_pan_x=0;
 int32_t previous_pan_y=0;
 bool has_pan_context=false;
 bool flip_enabled=false;
+bool hauled_enabled=false;
 
 // --- free camera -------------------------------------------------------------------------------
 // The camera is visually unbound from the tile grid. Two layered offsets:
@@ -360,8 +369,6 @@ void update_camera(
 		}
 }
 
-constexpr uint32_t fire_bits=0x70000000U;
-
 void update_visual_context(
 	const df::renderer_2d_base *renderer,
 	const df::graphic_viewportst *vp)
@@ -505,10 +512,19 @@ bool inside_clip(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 		y>=vp->clipy[0]&&y<=vp->clipy[1];
 }
 
+template<typename Flag>
+bool fire_frame(const Flag &flag)
+{
+	if constexpr(std::is_same_v<std::remove_cv_t<Flag>,uint32_t>)
+		return (flag&0x70000000U)!=0;
+	else
+		return flag.bits.fire_frame_type!=0;
+}
+
 bool has_fire(const df::graphic_viewportst *vp,int32_t x,int32_t y)
 {
 	return vp->screentexpos_spatter_flag!=nullptr&&
-		(vp->screentexpos_spatter_flag[x*vp->dim_y+y]&fire_bits)!=0;
+		fire_frame(vp->screentexpos_spatter_flag[x*vp->dim_y+y]);
 }
 
 template<typename T>
@@ -561,6 +577,17 @@ struct render_proxyst
 	SDL_Texture *texture;
 	bool mirrored=false;
 	int32_t mirror_shift=0;
+	std::set<std::pair<int32_t,int32_t>> coverage;
+};
+
+struct carried_item_proxyst
+{
+	float source_x;
+	float source_y;
+	int32_t target_x;
+	int32_t target_y;
+	float progress;
+	SDL_Texture *texture;
 	std::set<std::pair<int32_t,int32_t>> coverage;
 };
 
@@ -857,6 +884,112 @@ void draw_proxy(df::renderer_2d_base *renderer,const render_proxyst &proxy)
 		proxy.texture,
 		destination,
 		proxy.mirrored);
+}
+
+void draw_carried_item_proxy(
+	df::renderer_2d_base *renderer,
+	const carried_item_proxyst &proxy)
+{
+	const int32_t zoom=renderer->viewport_zoom_factor;
+	const float tile_size=float(zoom==128?32:std::max(1,zoom*32/128));
+	const float target_x=tile_pixel(proxy.target_x,renderer->origin_x,zoom);
+	const float target_y=tile_pixel(proxy.target_y,renderer->origin_y,zoom);
+	const float source_x=target_x+(proxy.source_x-proxy.target_x)*tile_size;
+	const float source_y=target_y+(proxy.source_y-proxy.target_y)*tile_size;
+	const auto icon=carried_item_icon_rect(
+		source_x+(target_x-source_x)*proxy.progress,
+		source_y+(target_y-source_y)*proxy.progress,
+		tile_size);
+	const SDL_FRect destination={icon.x,icon.y,icon.width,icon.height};
+	render_copy_f(
+		static_cast<SDL_Renderer *>(renderer->sdl_renderer),
+		proxy.texture,nullptr,&destination);
+}
+
+df::item *hauled_item(const df::unit *unit)
+{
+	if(unit==nullptr)return nullptr;
+	for(const df::unit_inventory_item *inventory_item:unit->inventory)
+		if(inventory_item!=nullptr&&inventory_item->item!=nullptr&&
+			inventory_item->mode==df::inv_item_role_type::Hauled)
+			return inventory_item->item;
+	return nullptr;
+}
+
+SDL_Texture *cached_viewport_texture(
+	df::renderer_2d_base *renderer,
+	df::graphic_viewportst *vp,
+	int32_t index,
+	int32_t texpos)
+{
+	if(texpos==0)return nullptr;
+	SDL_Texture *texture=cached_texture(renderer,texpos);
+	if(texture!=nullptr||vp->screentexpos_background_two==nullptr)return texture;
+	// Hauled items are not normally drawn, so stage one tile to populate the renderer cache.
+	scoped_value_restorest<int32_t> staged(vp->screentexpos_background_two[index]);
+	vp->screentexpos_background_two[index]=texpos;
+	renderer->update_viewport_tile(vp,index/vp->dim_y,index%vp->dim_y);
+	return cached_texture(renderer,texpos);
+}
+
+int32_t item_texpos(df::item *item)
+{
+	if(item==nullptr)return 0;
+	const MaterialInfo material(item);
+	if(!material.isValid())return 0;
+	switch(item->getType())
+		{
+		case df::item_type::BOULDER:
+			return material.material->boulder_texpos1!=0?
+				material.material->boulder_texpos1:
+				material.material->boulder_texpos2;
+		case df::item_type::BAR:
+			return material.material->bar_texpos;
+		case df::item_type::WOOD:
+			return material.material->wood_texpos;
+		default:
+			return 0;
+		}
+}
+
+std::vector<carried_item_proxyst> collect_carried_item_proxies(
+	df::renderer_2d_base *renderer,
+	df::graphic_viewportst *vp)
+{
+	std::vector<carried_item_proxyst> proxies;
+	if(window_x==nullptr||window_y==nullptr||window_z==nullptr)return proxies;
+
+	std::vector<df::unit *> units;
+	Units::getUnitsInBox(
+		units,
+		*window_x,*window_y,*window_z,
+		*window_x+vp->dim_x-1,*window_y+vp->dim_y-1,*window_z,
+		[](df::unit *unit){return !Units::isHidden(unit);});
+	for(const df::unit *unit:units)
+		{
+		const int32_t x=unit->pos.x-*window_x;
+		const int32_t y=unit->pos.y-*window_y;
+		if(!inside_clip(vp,x,y))continue;
+		const int32_t index=x*vp->dim_y+y;
+		if(vp->screentexpos[index]==0)continue;
+		const int32_t texpos=item_texpos(hauled_item(unit));
+		SDL_Texture *texture=cached_viewport_texture(renderer,vp,index,texpos);
+		if(texture==nullptr)continue;
+		const auto movement=animation_manager.get_movement(
+			vp,viewport_visual_layer::center,x,y);
+		const float source_x=movement.active?movement.source_x:float(x);
+		const float source_y=movement.active?movement.source_y:float(y);
+		carried_item_proxyst proxy={
+			source_x,source_y,x,y,movement.active?movement.progress:1.0f,texture,{}};
+		for(int32_t coverage_x=int32_t(std::floor(std::min(source_x,float(x))));
+			coverage_x<=int32_t(std::ceil(std::max(source_x,float(x))));++coverage_x)
+			for(int32_t coverage_y=int32_t(std::floor(std::min(source_y,float(y))));
+				coverage_y<=int32_t(std::ceil(std::max(source_y,float(y))));++coverage_y)
+				if(inside_clip(vp,coverage_x,coverage_y))
+					proxy.coverage.emplace(coverage_x,coverage_y);
+		proxies.push_back(std::move(proxy));
+		}
+	return proxies;
 }
 
 std::vector<render_proxyst> collect_proxies(
@@ -1195,7 +1328,8 @@ void redraw_viewport_tiles(
 void draw_viewport_interpolation_stages(
 	df::renderer_2d_base *renderer,
 	const std::vector<viewport_renderst> &viewports,
-	const tile_coveragest &coverage)
+	const tile_coveragest &coverage,
+	const std::vector<carried_item_proxyst> &carried_items)
 {
 	for(size_t index=0;index<viewports.size();++index)
 		{
@@ -1205,6 +1339,9 @@ void draw_viewport_interpolation_stages(
 		const viewport_renderst &viewport=viewports[index];
 		draw_interpolation_stages(
 			renderer,viewport.viewport,viewport.proxies,viewport.coverage);
+		if(index+1==viewports.size())
+			for(const carried_item_proxyst &proxy:carried_items)
+				draw_carried_item_proxy(renderer,proxy);
 		// A viewport shades everything drawn beneath it, so this covers every staged tile.
 		// Restricting it to the tiles this viewport has sprites on would not deepen with distance.
 		for(const auto &[x,y]:coverage)
@@ -1249,13 +1386,19 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		if(gps!=nullptr)++gps->force_full_display_count;
 		}
 	if(glide)camera_was_offset=true;
+	std::vector<carried_item_proxyst> carried_items=
+		hauled_enabled?collect_carried_item_proxies(renderer,vp):
+		std::vector<carried_item_proxyst>{};
 	if(!glide&&!animation_manager.requires_full_redraw()&&
-		(!flip_enabled||!has_mirrored_viewport_facing(viewports)))
+		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
+		carried_items.empty()&&previous_coverage.empty())
 		return;
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
 	tile_coveragest coverage=collect_viewport_coverage(viewport_renders);
+	for(const carried_item_proxyst &proxy:carried_items)
+		coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
 
 	SDL_Renderer *sdl_renderer=static_cast<SDL_Renderer *>(renderer->sdl_renderer);
 	const int32_t zoom=renderer->viewport_zoom_factor;
@@ -1293,7 +1436,8 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 			for(int32_t y=vp->clipy[0];y<=vp->clipy[1];++y)
 				redraw_world_tile(renderer,viewport_renders,coverage,x,y);
 			}
-		draw_viewport_interpolation_stages(renderer,viewport_renders,coverage);
+		draw_viewport_interpolation_stages(
+			renderer,viewport_renders,coverage,carried_items);
 		renderer->origin_x=saved_origin_x;
 		renderer->origin_y=saved_origin_y;
 		render_set_clip_rect(sdl_renderer,nullptr);
@@ -1327,7 +1471,8 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		if(inside_clip(vp,x,y))
 			redraw_world_tile(renderer,viewport_renders,coverage,x,y);
 		}
-	draw_viewport_interpolation_stages(renderer,viewport_renders,coverage);
+	draw_viewport_interpolation_stages(
+		renderer,viewport_renders,coverage,carried_items);
 
 	previous_coverage=std::move(coverage);
 }
@@ -1396,6 +1541,7 @@ void reset_state()
 	camera_has_prev=false;
 	camera_was_offset=false;
 	flip_enabled=false;
+	hauled_enabled=false;
 }
 
 command_result status_command(
@@ -1412,6 +1558,22 @@ command_result status_command(
 			camera_enabled?"on":"off",-rest_x,-rest_y);
 		out.print("sprite flipping: {}\n",
 			flip_enabled?"on":"off");
+		out.print("linear movement: {}\n",
+			animation_manager.is_linear()?"on":"off");
+		out.print("hauled item icons: {}\n",
+			hauled_enabled?"on":"off");
+		return CR_OK;
+		}
+	if(parameters[0]=="all")
+		{
+		if(parameters.size()!=2||
+			(parameters[1]!="on"&&parameters[1]!="off"))return CR_WRONG_USAGE;
+		const bool enabled=parameters[1]=="on";
+		flip_enabled=enabled;
+		animation_manager.set_linear(enabled);
+		hauled_enabled=enabled;
+		if(gps!=nullptr)++gps->force_full_display_count;
+		out.print("smooth-movement: all non-camera flags {}\n",parameters[1]);
 		return CR_OK;
 		}
 	if(parameters[0]=="camera")
@@ -1491,6 +1653,40 @@ command_result status_command(
 			}
 		return CR_WRONG_USAGE;
 		}
+	if(parameters[0]=="linear")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("linear movement: {}\n",
+				animation_manager.is_linear()?"on":"off");
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			animation_manager.set_linear(parameters[1]=="on");
+			out.print("smooth-movement: linear movement {}\n",parameters[1]);
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
+		}
+	if(parameters[0]=="hauled")
+		{
+		if(parameters.size()==1)
+			{
+			out.print("hauled item icons: {}\n",hauled_enabled?"on":"off");
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			hauled_enabled=parameters[1]=="on";
+			if(gps!=nullptr)++gps->force_full_display_count;
+			out.print("smooth-movement: hauled item icons {}\n",parameters[1]);
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
+		}
 	return CR_WRONG_USAGE;
 }
 
@@ -1502,7 +1698,9 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 	commands.emplace_back(
 		"smooth-movement",
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
-		"sprite flipping: flip on|off.",
+		"all non-camera flags: all on|off; "
+		"sprite flipping: flip on|off; linear movement: linear on|off; "
+		"hauled item icons: hauled on|off.",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1348,7 +1348,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	const bool paused=pause_state&&*pause_state;
 	if(paused)
 		{
-		animation_manager.cancel_transitions();
 		cancel_camera_transients();
 		camera_has_prev=false;
 		}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -598,6 +598,7 @@ struct render_proxyst
 	bool mirrored=false;
 	int32_t mirror_shift=0;
 	std::set<std::pair<int32_t,int32_t>> coverage;
+	visual_movement_idst movement_id=no_visual_movement;
 };
 
 struct carried_item_proxyst
@@ -1055,9 +1056,11 @@ std::vector<render_proxyst> collect_proxies(
 						if(anchor.layer==viewport_visual_layer::center&&
 							std::abs(anchor.target_x-x)<=1&&
 							std::abs(anchor.target_y-y)<=1&&
-							anchor.source_x-anchor.target_x==movement.source_x-x&&
+							(visual_layer!=viewport_visual_layer::designation?
+							anchor.movement_id==movement.movement_id:
+							(anchor.source_x-anchor.target_x==movement.source_x-x&&
 							anchor.source_y-anchor.target_y==movement.source_y-y&&
-							anchor.progress==movement.progress)anchored=true;
+							anchor.progress==movement.progress)))anchored=true;
 						}
 					if(!anchored)continue;
 					}
@@ -1092,9 +1095,7 @@ std::vector<render_proxyst> collect_proxies(
 						if(anchor.layer==viewport_visual_layer::center&&
 							anchor.target_x==x+descriptor.center_x&&
 							anchor.target_y==y+descriptor.center_y&&
-							anchor.source_x-anchor.target_x==movement.source_x-x&&
-							anchor.source_y-anchor.target_y==movement.source_y-y&&
-							anchor.progress==movement.progress)owns_fragment=true;
+							anchor.movement_id==movement.movement_id)owns_fragment=true;
 					if(!owns_fragment)continue;
 						}
 					}
@@ -1185,6 +1186,7 @@ std::vector<render_proxyst> collect_proxies(
 
 				proxy.texture=cached_texture(renderer,texpos);
 				if(proxy.texture==nullptr)continue;
+				proxy.movement_id=movement.movement_id;
 				proxies.push_back(std::move(proxy));
 				}
 			}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -28,6 +28,8 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <set>
@@ -53,6 +55,62 @@ REQUIRE_GLOBAL(window_z);
 namespace {
 
 constexpr const char *plugin_version="0.5.0";
+
+// Frame timing for `smooth-movement stats`. Counting is always on: one increment per frame,
+// one per painted frame, one per engine repaint. The clock is read three times per frame while
+// enabled. Sync covers movement detection across every viewport; render covers everything
+// after it, including the camera update and carried-item lookup that feed the draw decision,
+// then proxy collection, tile blanking, engine repaints and sprites. The render thread
+// writes, the console thread reads and clears, so the fields are relaxed atomics; a clear
+// that lands mid-frame skews that one frame and nothing else.
+struct frame_statsst
+{
+	std::atomic<bool> enabled{false};
+	std::atomic<uint64_t> frames{0};
+	std::atomic<uint64_t> painted{0};
+	std::atomic<uint64_t> repaints{0};
+	std::atomic<uint64_t> timed{0};
+	std::atomic<uint64_t> sync_us{0};
+	std::atomic<uint64_t> sync_max_us{0};
+	std::atomic<uint64_t> render_us{0};
+	std::atomic<uint64_t> render_max_us{0};
+
+	static uint64_t now_us()
+		{
+		return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+
+	void clear()
+		{
+		for(std::atomic<uint64_t> *counter:{&frames,&painted,&repaints,&timed,
+			&sync_us,&sync_max_us,&render_us,&render_max_us})
+			counter->store(0,std::memory_order_relaxed);
+		}
+
+	static void add(std::atomic<uint64_t> &total,std::atomic<uint64_t> &max,uint64_t us)
+		{
+		total.fetch_add(us,std::memory_order_relaxed);
+		uint64_t seen=max.load(std::memory_order_relaxed);
+		while(seen<us&&!max.compare_exchange_weak(seen,us,std::memory_order_relaxed)){}
+		}
+
+	void add_sync(uint64_t us){add(sync_us,sync_max_us,us);}
+	void add_render(uint64_t us){add(render_us,render_max_us,us);}
+};
+
+frame_statsst frame_stats;
+
+// Runs a callback when the scope ends, whichever return path is taken.
+template<typename Callback>
+struct scope_guardst
+{
+	Callback callback;
+	explicit scope_guardst(Callback c):callback(std::move(c)){}
+	~scope_guardst(){callback();}
+	scope_guardst(const scope_guardst &)=delete;
+	scope_guardst &operator=(const scope_guardst &)=delete;
+};
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -649,6 +707,13 @@ void with_upper_suppressed(
 		});
 }
 
+// Every engine repaint the plugin asks for goes through here so `stats` can count them.
+void engine_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,int32_t x,int32_t y)
+{
+	frame_stats.repaints.fetch_add(1,std::memory_order_relaxed);
+	renderer->update_viewport_tile(vp,x,y);
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -658,7 +723,7 @@ void redraw_viewport_tile(
 {
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto stage=[&]
 		{
 		with_suppressed_visual_layers(
@@ -701,7 +766,7 @@ void draw_interface_only(
 {
 	if(!interface_pass_readable(vp))return;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto without_visuals=[&]
 		{
 		with_suppressed_visual_layers(
@@ -764,7 +829,7 @@ void redraw_above(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		const auto stage=[&]
@@ -890,7 +955,7 @@ SDL_Texture *cached_viewport_texture(
 	// Hauled items are not normally drawn, so stage one tile to populate the renderer cache.
 	scoped_value_restorest<int32_t> staged(vp->screentexpos_background_two[index]);
 	vp->screentexpos_background_two[index]=texpos;
-	renderer->update_viewport_tile(vp,index/vp->dim_y,index%vp->dim_y);
+	engine_repaint(renderer,vp,index/vp->dim_y,index%vp->dim_y);
 	return cached_texture(renderer,texpos);
 }
 
@@ -1324,6 +1389,21 @@ bool has_mirrored_viewport_facing(
 
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
+	frame_stats.frames.fetch_add(1,std::memory_order_relaxed);
+	// Read once: if the console flipped the flag on mid-frame, the guard would subtract a
+	// start time of zero.
+	const bool timing_enabled=frame_stats.enabled.load(std::memory_order_relaxed);
+	const uint64_t frame_start_us=timing_enabled?frame_statsst::now_us():0;
+	uint64_t sync_end_us=frame_start_us;
+	// Runs on every exit, including the early return for frames with nothing to draw.
+	const scope_guardst timing([&]
+		{
+		if(!timing_enabled)return;
+		const uint64_t end_us=frame_statsst::now_us();
+		frame_stats.timed.fetch_add(1,std::memory_order_relaxed);
+		frame_stats.add_sync(sync_end_us-frame_start_us);
+		frame_stats.add_render(end_us-sync_end_us);
+		});
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
@@ -1342,6 +1422,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
+	if(timing_enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;
@@ -1374,6 +1455,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
 		carried_items.empty()&&previous_coverage.empty())
 		return;
+	frame_stats.painted.fetch_add(1,std::memory_order_relaxed);
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
@@ -1524,6 +1606,38 @@ void reset_state()
 	native_follow_id=-1;
 	flip_enabled=false;
 	hauled_enabled=false;
+	frame_stats.enabled=false;
+	frame_stats.clear();
+}
+
+void print_frame_stats(color_ostream &out)
+{
+	const auto get=[](const std::atomic<uint64_t> &v){return v.load(std::memory_order_relaxed);};
+	const uint64_t frames=get(frame_stats.frames),painted=get(frame_stats.painted),
+		repaints=get(frame_stats.repaints),timed=get(frame_stats.timed),
+		sync_us=get(frame_stats.sync_us),render_us=get(frame_stats.render_us);
+	out.print("frame stats: {}\n",frame_stats.enabled?"on":"off");
+	if(frames==0)
+		{
+		out.print("no frames counted\n");
+		return;
+		}
+	const auto mean=[](uint64_t total,uint64_t count)
+		{
+		return count==0?0.0:double(total)/double(count);
+		};
+	out.print("frames: {} ({} painted, {:.0f}%)\n",
+		frames,painted,100.0*mean(painted,frames));
+	out.print("engine tile repaints: {} ({:.1f} per frame, {:.1f} per painted frame)\n",
+		repaints,mean(repaints,frames),mean(repaints,painted));
+	if(timed==0)return;
+	out.print("timed frames: {}\n",timed);
+	out.print("sync: mean {:.0f} us, max {} us\n",
+		mean(sync_us,timed),get(frame_stats.sync_max_us));
+	out.print("render: mean {:.0f} us, max {} us\n",
+		mean(render_us,timed),get(frame_stats.render_max_us));
+	out.print("total: mean {:.0f} us per timed frame\n",
+		mean(sync_us+render_us,timed));
 }
 
 command_result status_command(
@@ -1544,7 +1658,33 @@ command_result status_command(
 			animation_manager.is_linear()?"on":"off");
 		out.print("hauled item icons: {}\n",
 			hauled_enabled?"on":"off");
+		out.print("frame stats: {}\n",
+			frame_stats.enabled?"on":"off");
 		return CR_OK;
+		}
+	if(parameters[0]=="stats")
+		{
+		if(parameters.size()==1)
+			{
+			print_frame_stats(out);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			const bool on=parameters[1]=="on";
+			if(on)frame_stats.clear();
+			frame_stats.enabled=on;
+			out.print("smooth-movement: frame stats {}\n",parameters[1]);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="reset")
+			{
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats reset\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
 		}
 	if(parameters[0]=="all")
 		{
@@ -1555,7 +1695,7 @@ command_result status_command(
 		animation_manager.set_linear(enabled);
 		hauled_enabled=enabled;
 		if(gps!=nullptr)++gps->force_full_display_count;
-		out.print("smooth-movement: all non-camera flags {}\n",parameters[1]);
+		out.print("smooth-movement: flip, linear and hauled {}\n",parameters[1]);
 		return CR_OK;
 		}
 	if(parameters[0]=="camera")
@@ -1680,9 +1820,10 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 	commands.emplace_back(
 		"smooth-movement",
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
-		"all non-camera flags: all on|off; "
+		"flip, linear and hauled together: all on|off; "
 		"sprite flipping: flip on|off; linear movement: linear on|off; "
-		"hauled item icons: hauled on|off.",
+		"hauled item icons: hauled on|off; "
+		"frame timing: stats [on|off|reset].",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -15,6 +15,7 @@
 #include "df/item.h"
 #include "df/item_type.h"
 #include "df/material.h"
+#include "df/plotinfost.h"
 #include "df/renderer_2d_base.h"
 #include "df/texture_fullid.h"
 #include "df/unit.h"
@@ -43,6 +44,8 @@ DFHACK_PLUGIN_IS_ENABLED(is_enabled);
 
 REQUIRE_GLOBAL(enabler);
 REQUIRE_GLOBAL(gps);
+REQUIRE_GLOBAL(pause_state);
+REQUIRE_GLOBAL(plotinfo);
 REQUIRE_GLOBAL(window_x);
 REQUIRE_GLOBAL(window_y);
 REQUIRE_GLOBAL(window_z);
@@ -94,11 +97,13 @@ double transient_x=0.0;                       // decaying glide offset, pixels
 double transient_y=0.0;
 double rest_x=0.0;                            // persistent free-camera offset, tiles
 double rest_y=0.0;                            // (positive = view sits WEST/NORTH of window)
-int32_t camera_pending_dx=0;                  // scroll delta announced but not yet in the buffers
-int32_t camera_pending_dy=0;
-int32_t camera_pending_frames=0;
 int32_t self_scroll_x=0;                      // window deltas WE wrote: visual no-ops when landing
 int32_t self_scroll_y=0;
+visual_movement_idst camera_follow_id=no_visual_movement;
+const void *camera_follow_viewport=nullptr;
+double camera_follow_x=0.0;
+double camera_follow_y=0.0;
+bool camera_ignore_pending=false;
 bool drag_active=false;
 double drag_anchor_vx=0.0;                    // visual camera at drag start, tiles
 double drag_anchor_vy=0.0;
@@ -108,6 +113,7 @@ bool camera_was_offset=false;                 // edge-detects offset->0 for one 
 int32_t camera_prev_wx=0;                     // window-scroll observation baseline
 int32_t camera_prev_wy=0;
 bool camera_has_prev=false;
+int32_t native_follow_id=-1;
 
 double tile_px(const df::renderer_2d_base *renderer)
 {
@@ -117,44 +123,24 @@ double tile_px(const df::renderer_2d_base *renderer)
 
 // Match ratio of "buffers shifted by (dwx,dwy)" on the background layer: 0..1, or -1 when there
 // is nothing to compare (empty background).
-double background_match_ratio(const df::graphic_viewportst *vp,int32_t dwx,int32_t dwy)
-{
-	int32_t considered=0;
-	int32_t matches=0;
-	for(int32_t x=0;x<vp->dim_x;++x)
-		{
-		const int32_t sx=x+dwx;
-		if(sx<0||sx>=vp->dim_x)continue;
-		for(int32_t y=0;y<vp->dim_y;++y)
-			{
-			const int32_t sy=y+dwy;
-			if(sy<0||sy>=vp->dim_y)continue;
-			const int32_t cur=vp->screentexpos_background[x*vp->dim_y+y];
-			if(cur==0)continue;
-			++considered;
-			if(vp->screentexpos_background_old[sx*vp->dim_y+sy]==cur)++matches;
-			}
-		}
-	if(considered==0)return -1.0;
-	return double(matches)/double(considered);
-}
-
 // Cancel everything except the persistent rest offset (the camera keeps its sub-tile position
 // across zoom/z/resize; only the in-flight animation state is unfollowable).
-void clear_camera_pending()
+void clear_camera_tracking()
 {
-	camera_pending_dx=0;
-	camera_pending_dy=0;
-	camera_pending_frames=0;
 	self_scroll_x=0;
 	self_scroll_y=0;
+	camera_follow_id=no_visual_movement;
+	camera_follow_viewport=nullptr;
+	camera_follow_x=0.0;
+	camera_follow_y=0.0;
+	camera_ignore_pending=false;
 }
 
 void cancel_camera_transients()
 {
 	transient_x=0.0;
 	transient_y=0.0;
-	clear_camera_pending();
+	clear_camera_tracking();
 	drag_active=false;
 }
 
@@ -187,47 +173,19 @@ void normalize_rest()
 		}
 }
 
-// A scroll of (ax,ay) tiles has landed in the buffers: our own normalization writes are visual
-// no-ops (they move into rest); the remainder is a real scroll and glides -- unless a drag is
-// driving the position directly, in which case it folds into rest wholesale.
-void attribute_landed(int32_t ax,int32_t ay,double tile)
-{
-	int32_t sx=0;
-	if(self_scroll_x!=0&&(self_scroll_x>0)==(ax>0)&&ax!=0)
-		sx=(std::abs(self_scroll_x)<=std::abs(ax))?self_scroll_x:ax;
-	int32_t sy=0;
-	if(self_scroll_y!=0&&(self_scroll_y>0)==(ay>0)&&ay!=0)
-		sy=(std::abs(self_scroll_y)<=std::abs(ay))?self_scroll_y:ay;
-	self_scroll_x-=sx;
-	self_scroll_y-=sy;
-	rest_x+=sx;
-	rest_y+=sy;
-	const int32_t gx=ax-sx;
-	const int32_t gy=ay-sy;
-	if(drag_active)
-		{
-		rest_x+=gx;
-		rest_y+=gy;
-		}
-	else
-		{
-		transient_x+=gx*tile;
-		transient_y+=gy*tile;
-		const double cap=tile*(camera_max_glide_tiles+0.5);
-		transient_x=std::clamp(transient_x,-cap,cap);
-		transient_y=std::clamp(transient_y,-cap,cap);
-		}
-}
-
 // Per-frame camera bookkeeping: observe window scrolls, attribute them when the buffers apply
 // them (glide vs our own normalization writes), drive the drag, decay the transient.
 void update_camera(
 	df::renderer_2d_base *renderer,
 	const df::graphic_viewportst *vp,
-	uint32_t delta_ms)
+	uint32_t delta_ms,
+	bool native_follow_active)
 {
-	if(!camera_enabled)return;
+	if(!camera_glide_enabled(camera_enabled,native_follow_active))return;
 	const double tile=tile_px(renderer);
+	const double k=std::exp(-double(delta_ms)/camera_tau_ms);
+	transient_x*=k;
+	transient_y*=k;
 	const int32_t wx=window_x?*window_x:0;
 	const int32_t wy=window_y?*window_y:0;
 	if(camera_has_prev&&(wx!=camera_prev_wx||wy!=camera_prev_wy))
@@ -236,79 +194,83 @@ void update_camera(
 		const int32_t dy=wy-camera_prev_wy;
 		if((std::abs(dx)>camera_max_glide_tiles||std::abs(dy)>camera_max_glide_tiles)&&
 			!drag_active)
-			cancel_camera_transients();   // teleport-like jump (recenter/minimap): snap
-		else
 			{
-			camera_pending_dx+=dx;
-			camera_pending_dy+=dy;
-			camera_pending_frames=0;
+			transient_x=0.0;
+			transient_y=0.0;
+			camera_follow_id=no_visual_movement;
+			camera_follow_x=0.0;
+			camera_follow_y=0.0;
+			camera_ignore_pending=true;
 			}
 		}
 	camera_prev_wx=wx;
 	camera_prev_wy=wy;
 	camera_has_prev=true;
 
-	if(camera_pending_dx!=0||camera_pending_dy!=0)
+	const visual_scroll_renderst scroll=animation_manager.get_scroll(vp);
+	if(scroll.abandoned)
 		{
-		if(std::abs(camera_pending_dx)>6||std::abs(camera_pending_dy)>6)
+		clear_camera_tracking();
+		}
+	if(scroll.landed)
+		{
+		int32_t sx=0;
+		if(self_scroll_x!=0&&scroll.landed_x!=0&&
+			(self_scroll_x>0)==(scroll.landed_x>0))
+			sx=std::abs(self_scroll_x)<=std::abs(scroll.landed_x)?
+				self_scroll_x:scroll.landed_x;
+		int32_t sy=0;
+		if(self_scroll_y!=0&&scroll.landed_y!=0&&
+			(self_scroll_y>0)==(scroll.landed_y>0))
+			sy=std::abs(self_scroll_y)<=std::abs(scroll.landed_y)?
+				self_scroll_y:scroll.landed_y;
+		self_scroll_x-=sx;
+		self_scroll_y-=sy;
+		rest_x+=sx;
+		rest_y+=sy;
+		const int32_t gx=scroll.landed_x-sx;
+		const int32_t gy=scroll.landed_y-sy;
+		const bool ignore=camera_ignore_pending;
+		if(!scroll.pending)camera_ignore_pending=false;
+		if(drag_active)
 			{
-			// Scrolling far outran detection: snap (keep rest, drop the animation debt).
+			rest_x+=gx;
+			rest_y+=gy;
+			}
+		else if((gx!=0||gy!=0)&&!ignore&&native_follow_active&&sx==0&&sy==0&&
+			scroll.follow_candidate!=no_visual_movement)
+			{
+			camera_follow_id=scroll.follow_candidate;
+			camera_follow_viewport=vp;
 			transient_x=0.0;
 			transient_y=0.0;
-			clear_camera_pending();
+			}
+		else if((gx!=0||gy!=0)&&!ignore)
+			{
+			camera_follow_id=no_visual_movement;
+			camera_follow_viewport=nullptr;
+			camera_follow_x=0.0;
+			camera_follow_y=0.0;
+			const double cap=tile*(camera_max_glide_tiles+0.5);
+			transient_x=std::clamp(transient_x+gx*tile,-cap,cap);
+			transient_y=std::clamp(transient_y+gy*tile,-cap,cap);
+			}
+		}
+	if(camera_follow_id!=no_visual_movement)
+		{
+		const auto follow=animation_manager.get_follow(
+			camera_follow_viewport,camera_follow_id);
+		if(follow.active)
+			{
+			camera_follow_x=follow.offset_x*tile;
+			camera_follow_y=follow.offset_y*tile;
 			}
 		else
 			{
-			// Fast scrolling applies the pending delta PIECEMEAL: the buffers may hold +1 of a
-			// pending +3 this frame. Testing only the total made landings miss, time out, and
-			// snap -- the fast-scroll jitter. Instead, find the LARGEST applied prefix of the
-			// pending scroll and attribute just that; the rest keeps pending. Ties between
-			// qualifying shifts only happen on uniform terrain, where mistiming is invisible.
-			const int32_t stepx=(camera_pending_dx>0)-(camera_pending_dx<0);
-			const int32_t stepy=(camera_pending_dy>0)-(camera_pending_dy<0);
-			int32_t best_ax=0,best_ay=0,best_mag=-1;
-			double best_score=-1.0;
-			bool no_data=false;
-			for(int32_t ix=0;ix<=std::abs(camera_pending_dx);++ix)
-				{
-				for(int32_t iy=0;iy<=std::abs(camera_pending_dy);++iy)
-					{
-					const double score=background_match_ratio(vp,ix*stepx,iy*stepy);
-					if(score<0.0){no_data=true;break;}
-					const int32_t mag=ix+iy;
-					if(score>=0.6&&(mag>best_mag||(mag==best_mag&&score>best_score)))
-						{
-						best_mag=mag;
-						best_score=score;
-						best_ax=ix*stepx;
-						best_ay=iy*stepy;
-						}
-					}
-				if(no_data)break;
-				}
-			if(no_data)
-				{
-				// Nothing to compare against (empty background): give up on attribution.
-				clear_camera_pending();
-				}
-			else if(best_mag>0)
-				{
-				attribute_landed(best_ax,best_ay,tile);
-				camera_pending_dx-=best_ax;
-				camera_pending_dy-=best_ay;
-				camera_pending_frames=0;
-				}
-			else if(best_mag==0)
-				{
-				// Content demonstrably hasn't moved yet: keep waiting, no timeout pressure.
-				camera_pending_frames=0;
-				}
-			else if(++camera_pending_frames>4)
-				{
-				// Neither static nor any prefix recognizable (heavy simultaneous change):
-				// drop the debt without touching the in-flight glide.
-				clear_camera_pending();
-				}
+			camera_follow_id=no_visual_movement;
+			camera_follow_viewport=nullptr;
+			camera_follow_x=0.0;
+			camera_follow_y=0.0;
 			}
 		}
 
@@ -316,18 +278,22 @@ void update_camera(
 	// released. DF's own drag still moves window in tile steps; rest carries the remainder.
 	// Positions are tracked against the CONTENT window (window minus unlanded jumps) so the
 	// buffer lag never causes a visible stutter.
-	const bool mbut=enabler!=nullptr&&enabler->mouse_mbut;
-	const double content_wx=double(wx-camera_pending_dx);
-	const double content_wy=double(wy-camera_pending_dy);
+	const bool mbut=camera_enabled&&enabler!=nullptr&&enabler->mouse_mbut;
+	const double content_wx=double(wx-scroll.pending_x);
+	const double content_wy=double(wy-scroll.pending_y);
 	if(mbut&&!drag_active&&gps!=nullptr)
 		{
 		drag_active=true;
-		drag_anchor_vx=content_wx-rest_x-transient_x/tile;
-		drag_anchor_vy=content_wy-rest_y-transient_y/tile;
+		drag_anchor_vx=content_wx-rest_x-(transient_x+camera_follow_x)/tile;
+		drag_anchor_vy=content_wy-rest_y-(transient_y+camera_follow_y)/tile;
 		drag_anchor_mx=gps->precise_mouse_x;
 		drag_anchor_my=gps->precise_mouse_y;
 		transient_x=0.0;
 		transient_y=0.0;
+		camera_follow_id=no_visual_movement;
+		camera_follow_viewport=nullptr;
+		camera_follow_x=0.0;
+		camera_follow_y=0.0;
 		}
 	if(drag_active)
 		{
@@ -356,16 +322,10 @@ void update_camera(
 			}
 		}
 
-	if(transient_x!=0.0||transient_y!=0.0)
+	if(std::abs(transient_x)<0.5&&std::abs(transient_y)<0.5)
 		{
-		const double k=std::exp(-double(delta_ms)/camera_tau_ms);
-		transient_x*=k;
-		transient_y*=k;
-		if(std::abs(transient_x)<0.5&&std::abs(transient_y)<0.5)
-			{
-			transient_x=0.0;
-			transient_y=0.0;
-			}
+		transient_x=0.0;
+		transient_y=0.0;
 		}
 }
 
@@ -490,6 +450,8 @@ viewport_visual_animation_inputst animation_input(df::graphic_viewportst *vp)
 		visual_context_revision,
 		visual_layers(const_viewport),
 		visual_layers(const_viewport,true),
+		vp->screentexpos_background,
+		vp->screentexpos_background_old,
 		window_x?*window_x:0,
 		window_y?*window_y:0
 		};
@@ -1366,6 +1328,15 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
 	if(vp!=nullptr)update_visual_context(renderer,vp);
+	const int32_t follow_id=plotinfo?plotinfo->follow_unit:-1;
+	if(native_follow_changed(native_follow_id,follow_id))
+		{
+		native_follow_id=follow_id;
+		++visual_context_revision;
+		previous_coverage.clear();
+		cancel_camera_transients();
+		camera_has_prev=false;
+		}
 	const uint32_t now_ms=Core::getInstance().p->getTickCount();
 	animation_manager.begin_frame(now_ms);
 	for(df::graphic_viewportst *viewport:viewports)
@@ -1374,10 +1345,23 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;
-	update_camera(renderer,vp,animation_manager.get_frame_delta_ms());
+	const bool paused=pause_state&&*pause_state;
+	if(paused)
+		{
+		animation_manager.cancel_transitions();
+		cancel_camera_transients();
+		rest_x=0.0;
+		rest_y=0.0;
+		camera_has_prev=false;
+		}
+	const bool native_follow_active=follow_id>=0;
+	if(!paused)
+		update_camera(renderer,vp,animation_manager.get_frame_delta_ms(),native_follow_active);
 	const double cam_tile=tile_px(renderer);
-	const int32_t glide_x=int32_t(std::lround(transient_x+rest_x*cam_tile));
-	const int32_t glide_y=int32_t(std::lround(transient_y+rest_y*cam_tile));
+	const int32_t glide_x=int32_t(std::lround(
+		transient_x+camera_follow_x+rest_x*cam_tile));
+	const int32_t glide_y=int32_t(std::lround(
+		transient_y+camera_follow_y+rest_y*cam_tile));
 	const bool glide=glide_x!=0||glide_y!=0;
 	if(!glide&&camera_was_offset)
 		{
@@ -1540,6 +1524,7 @@ void reset_state()
 	camera_enabled=false;
 	camera_has_prev=false;
 	camera_was_offset=false;
+	native_follow_id=-1;
 	flip_enabled=false;
 	hauled_enabled=false;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1350,8 +1350,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		{
 		animation_manager.cancel_transitions();
 		cancel_camera_transients();
-		rest_x=0.0;
-		rest_y=0.0;
 		camera_has_prev=false;
 		}
 	const bool native_follow_active=follow_id>=0;

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -38,6 +38,32 @@ void set_layer(
 	input.previous[index]=previous;
 }
 
+template<size_t N>
+void fill_background(std::array<int32_t,N> &background,int32_t seed)
+{
+	for(size_t i=0;i<N;++i)background[i]=seed+int32_t(i);
+}
+
+template<size_t N>
+void shift_background(
+	std::array<int32_t,N> &current,
+	const std::array<int32_t,N> &previous,
+	int32_t dimension,
+	int32_t dx,
+	int32_t dy,
+	int32_t exposed_seed)
+{
+	for(int32_t x=0;x<dimension;++x)
+		for(int32_t y=0;y<dimension;++y)
+			{
+			const int32_t sx=x+dx;
+			const int32_t sy=y+dy;
+			const size_t index=size_t(x*dimension+y);
+			current[index]=sx>=0&&sx<dimension&&sy>=0&&sy<dimension?
+				previous[size_t(sx*dimension+sy)]:exposed_seed+int32_t(index);
+			}
+}
+
 void run_frame(
 	visual_animation_managerst &manager,
 	const viewport_visual_animation_inputst &input,
@@ -84,6 +110,12 @@ int main()
 	assert(mirrored_tile_x(4,5)==6);   // left spill -> right
 	// The formula is a general reflection, so it holds for offsets no layer can express.
 	assert(mirrored_tile_x(8,5)==2);
+	assert(!camera_glide_enabled(false,false));
+	assert(camera_glide_enabled(false,true));
+	assert(camera_glide_enabled(true,false));
+	assert(native_follow_changed(-1,42));
+	assert(!native_follow_changed(42,42));
+	assert(native_follow_changed(42,-1));
 	// center_x is only ever -1, 0 or +1, so the real mirror shift is only ever -2, 0 or +2.
 	for(const auto &descriptor:visual_layer_descriptors)
 		assert(descriptor.center_x>=-1&&descriptor.center_x<=1);
@@ -125,6 +157,12 @@ int main()
 	assert(manager.get_facing(viewport,1,2)==visual_facingst::west);
 	set_layer(input,viewport_visual_layer::center,before,west_after);
 	run_frame(manager,input,1032);
+	assert(manager.get_facing(viewport,2,2)==visual_facingst::east);
+	assert(manager.get_movement(
+		viewport,viewport_visual_layer::center,2,2).active);
+	manager.cancel_transitions();
+	assert(!manager.get_movement(
+		viewport,viewport_visual_layer::center,2,2).active);
 	assert(manager.get_facing(viewport,2,2)==visual_facingst::east);
 	}
 
@@ -570,6 +608,7 @@ int main()
 	assert(!ambiguous.is_linear());
 	ambiguous.set_linear(true);
 	assert(ambiguous.is_linear());
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
 	run_frame(ambiguous,input,2990);
 	previous.fill(0);
 	previous[0*3+1]=42;
@@ -830,4 +869,107 @@ int main()
 		viewport,viewport_visual_layer::vehicle,2,1);
 	assert(chained.active&&chained.source_x>0.0f&&chained.source_x<1.0f&&
 		chained.progress==0.0f);
+
+	// Every cardinal and diagonal follow step gets a stable inverse visual anchor.
+	for(int32_t dx=-1;dx<=1;++dx)
+		for(int32_t dy=-1;dy<=1;++dy)
+			{
+			if(dx==0&&dy==0)continue;
+			constexpr int32_t dim=7;
+			constexpr size_t tiles=size_t(dim)*size_t(dim);
+			const int token=dx*3+dy;
+			std::array<int32_t,tiles> empty{};
+			std::array<int32_t,tiles> creature{};
+			std::array<int32_t,tiles> creature_old{};
+			std::array<int32_t,tiles> background{};
+			std::array<int32_t,tiles> background_old{};
+			fill_background(background_old,2000);
+			background=background_old;
+			const int32_t center=dim/2;
+			creature[size_t(center*dim+center)]=42;
+			creature_old=creature;
+			auto follow_input=make_input(&token,dim,empty.data());
+			set_layer(follow_input,viewport_visual_layer::center,
+				creature.data(),creature_old.data());
+			follow_input.current_background=background.data();
+			follow_input.previous_background=background_old.data();
+			visual_animation_managerst follow_manager;
+			run_frame(follow_manager,follow_input,20000);
+			follow_input.pan_x=dx;
+			follow_input.pan_y=dy;
+			run_frame(follow_manager,follow_input,20010);
+			shift_background(background,background_old,dim,dx,dy,3000);
+			run_frame(follow_manager,follow_input,20020);
+			const auto scroll=follow_manager.get_scroll(&token);
+			assert(scroll.landed&&scroll.landed_x==dx&&scroll.landed_y==dy&&
+				!scroll.pending&&scroll.follow_candidate!=no_visual_movement);
+			const auto movement=follow_manager.get_movement(
+				&token,viewport_visual_layer::center,center,center);
+			const auto follow=follow_manager.get_follow(&token,scroll.follow_candidate);
+			assert(movement.active&&follow.active&&
+				movement.movement_id==scroll.follow_candidate);
+			assert(std::abs((movement.source_x-center)*(1.0f-movement.progress)+
+				follow.offset_x)<0.000001f);
+			assert(std::abs((movement.source_y-center)*(1.0f-movement.progress)+
+				follow.offset_y)<0.000001f);
+			run_frame(follow_manager,follow_input,20095);
+			const auto fractional=follow_manager.get_follow(&token,scroll.follow_candidate);
+			assert(fractional.active&&std::abs(fractional.offset_x)<1.0f&&
+				std::abs(fractional.offset_y)<1.0f);
+			}
+
+	// A multi-tile announcement may land partially, then retire the remaining debt.
+	{
+	constexpr int32_t dim=6;
+	constexpr size_t tiles=size_t(dim)*size_t(dim);
+	const int token=0;
+	std::array<int32_t,tiles> empty{};
+	std::array<int32_t,tiles> background{};
+	std::array<int32_t,tiles> background_old{};
+	fill_background(background_old,4000);
+	background=background_old;
+	auto input=make_input(&token,dim,empty.data());
+	input.current_background=background.data();
+	input.previous_background=background_old.data();
+	visual_animation_managerst partial;
+	run_frame(partial,input,21000);
+	input.pan_x=3;
+	run_frame(partial,input,21010);
+	shift_background(background,background_old,dim,1,0,5000);
+	run_frame(partial,input,21020);
+	auto scroll=partial.get_scroll(&token);
+	assert(scroll.landed&&scroll.landed_x==1&&scroll.pending&&scroll.pending_x==2);
+	background_old=background;
+	shift_background(background,background_old,dim,2,0,6000);
+	run_frame(partial,input,21030);
+	scroll=partial.get_scroll(&token);
+	assert(scroll.landed&&scroll.landed_x==2&&!scroll.pending);
+	}
+
+	// Uniform terrain is visually safe to retire; absent data abandons without an offset.
+	{
+	constexpr int32_t dim=4;
+	constexpr size_t tiles=size_t(dim)*size_t(dim);
+	const int uniform_token=0,empty_token=1;
+	std::array<int32_t,tiles> empty{};
+	std::array<int32_t,tiles> uniform{};
+	uniform.fill(77);
+	auto input=make_input(&uniform_token,dim,empty.data());
+	input.current_background=uniform.data();
+	input.previous_background=uniform.data();
+	visual_animation_managerst manager;
+	run_frame(manager,input,22000);
+	input.pan_x=1;
+	run_frame(manager,input,22010);
+	assert(manager.get_scroll(&uniform_token).landed);
+	auto empty_input=make_input(&empty_token,dim,empty.data());
+	empty_input.current_background=empty.data();
+	empty_input.previous_background=empty.data();
+	visual_animation_managerst empty_manager;
+	run_frame(empty_manager,empty_input,22100);
+	empty_input.pan_x=1;
+	run_frame(empty_manager,empty_input,22110);
+	const auto abandoned=empty_manager.get_scroll(&empty_token);
+	assert(abandoned.abandoned&&!abandoned.pending);
+	}
 }

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -470,6 +470,34 @@ int main()
 	assert(visual_layer_descriptor(viewport_visual_layer::upleft).center_x==1&&
 		visual_layer_descriptor(viewport_visual_layer::upleft).center_y==1);
 
+	// A fragment follows its exact anchor even when another nearby creature moves differently.
+	{
+	constexpr int32_t dim=5;
+	int32_t empty[dim*dim]={};
+	int32_t before[dim*dim]={};
+	int32_t after[dim*dim]={};
+	before[1*dim+2]=11;
+	before[3*dim+2]=22;
+	after[2*dim+2]=11; // east
+	after[3*dim+1]=22; // north
+	const int token=0;
+	const void *crowded_viewport=&token;
+	visual_animation_managerst crowded;
+	auto crowded_input=make_input(crowded_viewport,dim,empty);
+	set_layer(crowded_input,viewport_visual_layer::center,before,empty);
+	run_frame(crowded,crowded_input,1000);
+	set_layer(crowded_input,viewport_visual_layer::center,after,before);
+	run_frame(crowded,crowded_input,1016);
+	const auto anchor=crowded.get_movement(
+		crowded_viewport,viewport_visual_layer::center,2,2);
+	const auto fragment=crowded.get_movement(
+		crowded_viewport,viewport_visual_layer::right,3,2);
+	assert(anchor.active&&fragment.active&&fragment.inherited);
+	assert(fragment.movement_id==anchor.movement_id);
+	assert(fragment.source_x==2&&fragment.source_y==2);
+	assert(fragment.progress==anchor.progress);
+	}
+
 	std::array<int32_t,9> empty{};
 	std::array<int32_t,9> current{};
 	std::array<int32_t,9> previous{};

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -413,7 +413,14 @@ int main()
 	assert(manager.get_facing(gap_viewport,2,3)==native_sprite_facing);
 	}
 
-	assert(animation_progress(100,0,100)==1.0f);
+	assert(animation_progress(150,0,150)==1.0f);
+	assert(animation_progress(75,0,150)==0.5f);
+	assert(animation_progress(75,0,150,true)==0.5f);
+	assert(animation_progress(25,0,150,true)==float(1)/6);
+	assert(animation_progress(25,0,150)<float(1)/6);
+	const auto carried_icon=carried_item_icon_rect(100.0f,200.0f,20.0f);
+	assert(carried_icon.x==101.0f&&carried_icon.y==204.0f);
+	assert(carried_icon.width==14.0f&&carried_icon.height==14.0f);
 	assert(inherited_visual_source_tile(0,0,1)==-1);
 	assert(inherited_visual_source_tile(2,0,1)==1);
 	assert(visual_layer_descriptor(viewport_visual_layer::right).center_x==-1);
@@ -447,20 +454,122 @@ int main()
 
 	previous=current;
 	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
-	run_frame(movement,input,2050);
+	run_frame(movement,input,2075);
 	render=movement.get_movement(viewport,viewport_visual_layer::center,1,1);
 	assert(render.active);
 	assert(render.progress==0.5f);
 
-	run_frame(movement,input,2100);
+	run_frame(movement,input,2150);
 	assert(!movement.get_movement(
 		viewport,viewport_visual_layer::center,1,1).active);
 	assert(movement.requires_full_redraw());
 
-	run_frame(movement,input,2120);
+	run_frame(movement,input,2170);
 	assert(!movement.requires_full_redraw());
 
+	visual_animation_managerst linear_movement;
+	linear_movement.set_linear(true);
+	current.fill(0);
+	previous.fill(0);
+	set_layer(input,viewport_visual_layer::center,current.data(),previous.data());
+	run_frame(linear_movement,input,2190);
+	previous[0*3+1]=42;
+	current[1*3+1]=42;
+	run_frame(linear_movement,input,2200);
+	previous=current;
+	run_frame(linear_movement,input,2225);
+	assert(linear_movement.get_movement(
+		viewport,viewport_visual_layer::center,1,1).progress==float(1)/6);
+
+	// Linear cadence follows the latest step, while completed movement stays silent history.
+	{
+	std::array<int32_t,9> at_zero{};
+	std::array<int32_t,9> at_one{};
+	std::array<int32_t,9> at_two{};
+	at_zero[0*3+1]=42;
+	at_one[1*3+1]=42;
+	at_two[2*3+1]=42;
+
+	visual_animation_managerst adaptive;
+	adaptive.set_linear(true);
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),empty.data());
+	run_frame(adaptive,input,1000);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(adaptive,input,1010);
+	run_frame(adaptive,input,1085);
+	assert(adaptive.get_movement(
+		viewport,viewport_visual_layer::center,1,1).progress==0.5f); // first: 150 ms
+	run_frame(adaptive,input,1160);
+	assert(!adaptive.get_movement(
+		viewport,viewport_visual_layer::center,1,1).active);
+	run_frame(adaptive,input,1161);
+	assert(!adaptive.requires_full_redraw());
+	set_layer(input,viewport_visual_layer::center,at_two.data(),at_one.data());
+	run_frame(adaptive,input,1310);
+	run_frame(adaptive,input,1460);
+	assert(adaptive.get_movement(
+		viewport,viewport_visual_layer::center,2,1).progress==0.5f); // cadence: 300 ms
+
+	visual_animation_managerst minimum;
+	minimum.set_linear(true);
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),empty.data());
+	run_frame(minimum,input,2000);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(minimum,input,2010);
+	set_layer(input,viewport_visual_layer::center,at_two.data(),at_one.data());
+	run_frame(minimum,input,2110);
+	run_frame(minimum,input,2185);
+	assert(minimum.get_movement(
+		viewport,viewport_visual_layer::center,2,1).progress==0.5f); // clamped to 150 ms
+
+	visual_animation_managerst maximum;
+	maximum.set_linear(true);
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),empty.data());
+	run_frame(maximum,input,3000);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(maximum,input,3010);
+	set_layer(input,viewport_visual_layer::center,at_two.data(),at_one.data());
+	run_frame(maximum,input,3510);
+	run_frame(maximum,input,3760);
+	assert(maximum.get_movement(
+		viewport,viewport_visual_layer::center,2,1).progress==0.5f); // clamped to 500 ms
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_two.data());
+	run_frame(maximum,input,4111);
+	run_frame(maximum,input,4186);
+	assert(maximum.get_movement(
+		viewport,viewport_visual_layer::center,1,1).progress==0.5f); // history expired: 150 ms
+
+	// Reversal leaves two predecessors at B; the newer B->A step must win for A->B.
+	visual_animation_managerst reversal;
+	reversal.set_linear(true);
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),empty.data());
+	run_frame(reversal,input,4000);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(reversal,input,4010);
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),at_one.data());
+	run_frame(reversal,input,4310);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(reversal,input,4510);
+	run_frame(reversal,input,4610);
+	assert(reversal.get_movement(
+		viewport,viewport_visual_layer::center,1,1).progress==0.5f); // latest cadence: 200 ms
+
+	visual_animation_managerst smoothstep;
+	set_layer(input,viewport_visual_layer::center,at_zero.data(),empty.data());
+	run_frame(smoothstep,input,5000);
+	set_layer(input,viewport_visual_layer::center,at_one.data(),at_zero.data());
+	run_frame(smoothstep,input,5010);
+	set_layer(input,viewport_visual_layer::center,at_two.data(),at_one.data());
+	run_frame(smoothstep,input,5110);
+	run_frame(smoothstep,input,5185);
+	assert(smoothstep.get_movement(
+		viewport,viewport_visual_layer::center,2,1).progress==0.5f); // fixed 150 ms
+	}
+
 	visual_animation_managerst ambiguous;
+	assert(!ambiguous.is_linear());
+	ambiguous.set_linear(true);
+	assert(ambiguous.is_linear());
 	run_frame(ambiguous,input,2990);
 	previous.fill(0);
 	previous[0*3+1]=42;
@@ -652,7 +761,7 @@ int main()
 	assert(carried_item.active&&carried_item.inherited);
 	previous=current;
 	status_current[1*3+0]=92;
-	run_frame(companion,input,9050);
+	run_frame(companion,input,9075);
 	status=companion.get_movement(viewport,viewport_visual_layer::designation,1,0);
 	assert(status.active&&status.progress==0.5f);
 
@@ -709,7 +818,7 @@ int main()
 		viewport,viewport_visual_layer::vehicle,1,1).active);
 	previous=current;
 	current[1*3+1]=79;
-	run_frame(vehicle,input,12050);
+	run_frame(vehicle,input,12075);
 	const auto cart=vehicle.get_movement(
 		viewport,viewport_visual_layer::vehicle,1,1);
 	assert(cart.active&&cart.progress==0.5f);

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 
 enum class viewport_visual_layer : uint8_t
@@ -131,6 +132,8 @@ struct viewport_visual_animation_inputst
 	uint64_t context_revision=0;
 	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> current{};
 	std::array<const int32_t *,static_cast<size_t>(viewport_visual_layer::count)> previous{};
+	const int32_t *current_background=nullptr;
+	const int32_t *previous_background=nullptr;
 	// Current map-scroll offset (window_x/window_y). A pure pan does not bump context_revision.
 	// Only a hint: it changes at input time, the buffers shift on a later render frame.
 	int32_t pan_x=0;
@@ -154,6 +157,30 @@ struct visual_movement_renderst
 	float source_y=0.0f;
 	float progress=1.0f;
 	bool inherited=false;
+	uint64_t movement_id=0;
+};
+
+using visual_movement_idst=uint64_t;
+constexpr visual_movement_idst no_visual_movement=0;
+
+struct visual_scroll_renderst
+{
+	bool pending=false;
+	bool landed=false;
+	bool abandoned=false;
+	int32_t landed_x=0;
+	int32_t landed_y=0;
+	int32_t pending_x=0;
+	int32_t pending_y=0;
+	visual_movement_idst follow_candidate=no_visual_movement;
+};
+
+struct visual_follow_renderst
+{
+	bool active=false;
+	visual_movement_idst movement_id=no_visual_movement;
+	float offset_x=0.0f;
+	float offset_y=0.0f;
 };
 
 struct visual_icon_rectst
@@ -175,6 +202,16 @@ constexpr visual_icon_rectst carried_item_icon_rect(
 		tile_size*0.7f,
 		tile_size*0.7f
 		};
+}
+
+constexpr bool camera_glide_enabled(bool camera_enabled,bool native_follow_active)
+{
+	return camera_enabled||native_follow_active;
+}
+
+constexpr bool native_follow_changed(int32_t previous_id,int32_t current_id)
+{
+	return previous_id!=current_id;
 }
 
 inline float animation_progress(
@@ -236,6 +273,7 @@ class visual_animation_managerst
 {
 	struct movementst
 	{
+		visual_movement_idst id=no_visual_movement;
 		viewport_visual_layer layer;
 		int32_t texpos;
 		float source_x;
@@ -277,6 +315,10 @@ class visual_animation_managerst
 		bool has_buffer_signature=false;
 		// Set while the previous buffer still belongs to a view that has been left behind.
 		bool previous_view_stale=false;
+		bool landed_this_frame=false;
+		bool abandoned_this_frame=false;
+		std::array<int32_t,2> landed_shift{};
+		visual_movement_idst follow_candidate=no_visual_movement;
 	};
 
 	uint32_t frame_time_ms=0;
@@ -284,11 +326,13 @@ class visual_animation_managerst
 	bool has_frame=false;
 	bool force_full_redraw=false;
 	bool linear=false;
+	visual_movement_idst next_movement_id=1;
 	std::vector<viewport_animationst> viewports;
 
 	static constexpr uint32_t movement_duration_ms=150;
 	// Scrolling faster than detection keeps up: give up rather than test ever more prefixes.
 	static constexpr size_t max_pending_shifts=8;
+	static constexpr int32_t max_pending_shift_debt=6;
 	// Bounds the wait on a scroll that never lands, so suppression cannot stick forever.
 	static constexpr int32_t max_pending_age_frames=120;
 
@@ -297,6 +341,26 @@ class visual_animation_managerst
 		state.pending.clear();
 		state.pending_frames=0;
 		state.pending_age=0;
+		}
+
+	static std::array<int32_t,2> pending_total(const viewport_animationst &state)
+		{
+		std::array<int64_t,2> total{};
+		for(const auto &shift:state.pending)
+			{
+			total[0]+=shift[0];
+			total[1]+=shift[1];
+			}
+		return {
+			int32_t(std::clamp(total[0],int64_t(INT32_MIN),int64_t(INT32_MAX))),
+			int32_t(std::clamp(total[1],int64_t(INT32_MIN),int64_t(INT32_MAX)))
+			};
+		}
+
+	static int32_t saturated_pan_delta(int32_t current,int32_t previous)
+		{
+		return int32_t(std::clamp(
+			int64_t(current)-previous,int64_t(INT32_MIN),int64_t(INT32_MAX)));
 		}
 
 	static void abandon_pending(viewport_animationst &state)
@@ -328,6 +392,12 @@ class visual_animation_managerst
 		constexpr uint64_t fnv_prime=0x100000001b3ULL;
 		uint64_t hash=fnv_offset_basis;
 		const int32_t tile_count=input.dim_x*input.dim_y;
+		if(input.current_background!=nullptr&&input.previous_background!=nullptr)
+			for(int32_t i=0;i<tile_count;++i)
+				{
+				hash=(hash^uint64_t(uint32_t(input.current_background[i])))*fnv_prime;
+				hash=(hash^uint64_t(uint32_t(input.previous_background[i])))*fnv_prime;
+				}
 		for(size_t layer=0;layer<input.current.size();++layer)
 			{
 			if(!visual_layer_tracks_own_movement(
@@ -343,7 +413,32 @@ class visual_animation_managerst
 
 	// Fraction of tracked sprites consistent with a buffer shift: current[x]==previous[x+dwx].
 	// Negative when there is nothing to compare.
-	static double shift_match_ratio(
+	static double background_shift_match_ratio(
+		const viewport_visual_animation_inputst &input,
+		int32_t dwx,
+		int32_t dwy)
+		{
+		if(input.current_background==nullptr||input.previous_background==nullptr)return -1.0;
+		int32_t considered=0;
+		int32_t matches=0;
+		for(int32_t x=0;x<input.dim_x;++x)
+			{
+			const int32_t sx=x+dwx;
+			if(sx<0||sx>=input.dim_x)continue;
+			for(int32_t y=0;y<input.dim_y;++y)
+				{
+				const int32_t sy=y+dwy;
+				if(sy<0||sy>=input.dim_y)continue;
+				const int32_t value=input.current_background[x*input.dim_y+y];
+				if(value==0)continue;
+				++considered;
+				if(input.previous_background[sx*input.dim_y+sy]==value)++matches;
+				}
+			}
+		return considered?double(matches)/considered:-1.0;
+		}
+
+	static double visual_shift_match_ratio(
 		const viewport_visual_animation_inputst &input,
 		int32_t dwx,
 		int32_t dwy)
@@ -376,6 +471,17 @@ class visual_animation_managerst
 			}
 		if(considered==0)return -1.0;
 		return double(matches)/double(considered);
+		}
+
+	static double scroll_shift_match_ratio(
+		const viewport_visual_animation_inputst &input,
+		int32_t dwx,
+		int32_t dwy,
+		bool &used_background)
+		{
+		const double background=background_shift_match_ratio(input,dwx,dwy);
+		used_background=background>=0.0;
+		return used_background?background:visual_shift_match_ratio(input,dwx,dwy);
 		}
 
 	static std::array<int32_t,2> shared_movement_delta(
@@ -444,6 +550,13 @@ class visual_animation_managerst
 			(linear?movement.duration_ms:movement_duration_ms);
 		}
 
+	visual_movement_idst allocate_movement_id()
+		{
+		const visual_movement_idst id=next_movement_id++;
+		if(next_movement_id==no_visual_movement)next_movement_id=1;
+		return id;
+		}
+
 	public:
 		visual_animation_managerst()=default;
 
@@ -467,6 +580,10 @@ class visual_animation_managerst
 			for(viewport_animationst &state:viewports)
 				{
 				state.seen=false;
+				state.landed_this_frame=false;
+				state.abandoned_this_frame=false;
+				state.landed_shift={};
+				state.follow_candidate=no_visual_movement;
 				for(movementst &movement:state.movements)
 					{
 					if(movement.historical)continue;
@@ -507,9 +624,19 @@ class visual_animation_managerst
 					// Same give-up as the other two sites: the owed shifts are unknowable now.
 					abandon_pending(state);
 					reset_facing(state);
+					state.abandoned_this_frame=true;
 					}
 				state.pending.push_back(
-					{input.pan_x-state.pan_x,input.pan_y-state.pan_y});
+					{saturated_pan_delta(input.pan_x,state.pan_x),
+						saturated_pan_delta(input.pan_y,state.pan_y)});
+				const auto debt=pending_total(state);
+				if(std::abs(int64_t(debt[0]))>max_pending_shift_debt||
+					std::abs(int64_t(debt[1]))>max_pending_shift_debt)
+					{
+					abandon_pending(state);
+					reset_facing(state);
+					state.abandoned_this_frame=true;
+					}
 				state.pending_frames=0;
 				state.suppress_frames=2;
 				}
@@ -556,44 +683,75 @@ class visual_animation_managerst
 
 			bool translated=false;
 			std::array<int32_t,2> landed_shift{};
-			if(buffers_advanced&&!crossed_views&&!state.pending.empty())
+			bool pending_testable=buffers_advanced;
+			bool repeated_landing_allowed=false;
+			if(!pending_testable&&!state.pending.empty())
 				{
-				// Queued scrolls land in order and may coalesce, so each hypothesis is a prefix.
-				// Shortest first: over-retiring leaves owed shifts to be read as movement.
-				std::array<int32_t,2> landed{};
-				size_t landed_count=0;
-				bool any_data=false;
-				std::array<int32_t,2> shift{};
-				for(size_t count=1;count<=state.pending.size();++count)
+				bool used_background=false;
+				const double ratio=scroll_shift_match_ratio(input,0,0,used_background);
+				pending_testable=ratio<0.0||ratio>=(used_background?0.6:0.5);
+				repeated_landing_allowed=used_background&&ratio>=0.6&&
+					visual_shift_match_ratio(input,0,0)<0.0;
+				}
+			if(pending_testable&&!crossed_views&&!state.pending.empty())
+				{
+				struct landing_candidatest
 					{
-					shift[0]+=state.pending[count-1][0];
-					shift[1]+=state.pending[count-1][1];
-					// A prefix netting to zero is indistinguishable from "nothing landed yet".
-					// Accepting it would retire shifts the buffers have still to apply.
-					if(shift[0]==0&&shift[1]==0)continue;
-					const double ratio=shift_match_ratio(input,shift[0],shift[1]);
-					// Emptiness is per-prefix: a long one can push every sprite out of range
-					// while a shorter one still has something to say.
-					if(ratio<0.0)continue;
-					any_data=true;
-					if(ratio>=0.5)
+					std::array<int32_t,2> shift{};
+					size_t full_events=0;
+					std::array<int32_t,2> partial{};
+					int32_t applied_components=0;
+					double score=-1.0;
+					bool valid=false;
+					};
+				landing_candidatest best;
+				bool any_data=false;
+				std::array<int32_t,2> base{};
+				int32_t base_components=0;
+				for(size_t event_index=0;event_index<state.pending.size();++event_index)
+					{
+					const auto event=state.pending[event_index];
+					const int32_t step_x=(event[0]>0)-(event[0]<0);
+					const int32_t step_y=(event[1]>0)-(event[1]<0);
+					for(int32_t ix=0;ix<=std::abs(event[0]);++ix)
+						for(int32_t iy=0;iy<=std::abs(event[1]);++iy)
 						{
-						landed=shift;
-						landed_count=count;
-						break;
+						if(ix==0&&iy==0)continue;
+						const std::array<int32_t,2> partial={ix*step_x,iy*step_y};
+						const std::array<int32_t,2> shift=
+							{base[0]+partial[0],base[1]+partial[1]};
+						if(shift[0]==0&&shift[1]==0)continue;
+						bool used_background=false;
+						const double ratio=scroll_shift_match_ratio(
+							input,shift[0],shift[1],used_background);
+						if(ratio<0.0)continue;
+						any_data=true;
+						const int32_t applied=base_components+ix+iy;
+						if(ratio<(used_background?0.6:0.5)||
+							(!buffers_advanced&&!repeated_landing_allowed)||
+							(best.valid&&ratio<best.score)||
+							(best.valid&&ratio==best.score&&applied>=best.applied_components))
+							continue;
+						const bool complete=ix==std::abs(event[0])&&iy==std::abs(event[1]);
+						best={shift,event_index+(complete?1:0),
+							complete?std::array<int32_t,2>{}:partial,applied,ratio,true};
 						}
+					base[0]+=event[0];
+					base[1]+=event[1];
+					base_components+=std::abs(event[0])+std::abs(event[1]);
 					}
 				if(!any_data)
 					{
 					// Nothing visible to anchor the test on: nothing to animate either.
 					abandon_pending(state);
 					reset_facing(state);
+					state.abandoned_this_frame=true;
 					}
-				else if(landed_count>0)
+				else if(best.valid)
 					{
 					// Re-anchor in-flight movements and drop anything scrolled off-screen.
-					const int32_t dwx=landed[0];
-					const int32_t dwy=landed[1];
+					const int32_t dwx=best.shift[0];
+					const int32_t dwy=best.shift[1];
 					state.movements.erase(
 						std::remove_if(
 							state.movements.begin(),
@@ -628,35 +786,43 @@ class visual_animation_managerst
 							}
 						state.facing.swap(shifted);
 						}
-					state.pending.erase(
-						state.pending.begin(),
-						state.pending.begin()+std::ptrdiff_t(landed_count));
+					state.pending.erase(state.pending.begin(),
+						state.pending.begin()+std::ptrdiff_t(best.full_events));
+					if(best.partial[0]!=0||best.partial[1]!=0)
+						{
+						state.pending.front()[0]-=best.partial[0];
+						state.pending.front()[1]-=best.partial[1];
+						if(state.pending.front()[0]==0&&state.pending.front()[1]==0)
+							state.pending.erase(state.pending.begin());
+						}
 					state.pending_frames=0;
 					state.pending_age=0;
 					// The scroll is accounted for; the settle window must not block the rebased pass.
 					state.suppress_frames=0;
-					landed_shift=landed;
+					landed_shift=best.shift;
 					translated=true;
+					state.landed_this_frame=true;
+					state.landed_shift=best.shift;
 					}
-				else if(shift_match_ratio(input,0,0)>=0.5&&
-					++state.pending_age<=max_pending_age_frames)
+				else
 					{
-					// The buffers have not moved yet, so the scroll is still in flight.
-					state.pending_frames=0;
-					}
-				else if(++state.pending_frames>4)
-					{
-					// The shift never showed up recognizably: fall back to the safe reset.
-					abandon_pending(state);
-					// The delta was never identified, so the grid cannot be translated.
-					reset_facing(state);
-					// It may yet land, so do not resume detection on the very next redraw.
-					state.suppress_frames=2;
+					bool used_background=false;
+					const double ratio=scroll_shift_match_ratio(input,0,0,used_background);
+					if(ratio>=(used_background?0.6:0.5)&&
+						++state.pending_age<=max_pending_age_frames)
+						state.pending_frames=0;
+					else if(++state.pending_frames>4||state.pending_age>max_pending_age_frames)
+						{
+						abandon_pending(state);
+						reset_facing(state);
+						state.suppress_frames=2;
+						state.abandoned_this_frame=true;
+						}
 					}
 				}
 
-			const bool suppress=!buffers_advanced||crossed_views||
-				!state.pending.empty()||state.suppress_frames>0;
+			const bool suppress=(!buffers_advanced&&!translated)||crossed_views||
+				(!translated&&!state.pending.empty())||state.suppress_frames>0;
 			// The countdown measures redraws, not frames, so a repeated viewport must not spend it.
 			if(buffers_advanced&&state.suppress_frames>0)--state.suppress_frames;
 
@@ -699,6 +865,7 @@ class visual_animation_managerst
 				// A source can be another movement's target in the same frame -- a chain.
 				std::vector<uint8_t> facing_target_written;
 				std::vector<int32_t> pending_facing_source_clears;
+				long double best_follow_distance=std::numeric_limits<long double>::max();
 				if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
 					facing_target_written.assign(state.facing.size(),0);
 				for(size_t layer=0;layer<input.current.size();++layer)
@@ -803,8 +970,10 @@ class visual_animation_managerst
 									frame_time_ms-predecessor->start_time_ms,
 									movement_duration_ms,500U);
 								}
+							const visual_movement_idst movement_id=allocate_movement_id();
 							state.movements.push_back(
 								{
+								movement_id,
 								static_cast<viewport_visual_layer>(layer),
 								texpos,
 								visual_source_x,
@@ -814,6 +983,24 @@ class visual_animation_managerst
 								frame_time_ms,
 								duration_ms
 								});
+							const int32_t source_x=source/input.dim_y;
+							const int32_t source_y=source%input.dim_y;
+							if(translated&&static_cast<viewport_visual_layer>(layer)==
+								viewport_visual_layer::center&&
+								x-source_x==landed_shift[0]&&y-source_y==landed_shift[1])
+								{
+								const long double centered_x=
+									static_cast<long double>(2)*x-(input.dim_x-1);
+								const long double centered_y=
+									static_cast<long double>(2)*y-(input.dim_y-1);
+								const long double distance=
+									centered_x*centered_x+centered_y*centered_y;
+								if(distance<best_follow_distance)
+									{
+									best_follow_distance=distance;
+									state.follow_candidate=movement_id;
+									}
+								}
 							if(static_cast<viewport_visual_layer>(layer)==
 									viewport_visual_layer::center&&
 								state.facing.size()==
@@ -821,11 +1008,10 @@ class visual_animation_managerst
 								!facing_at_frame_start.empty()&&
 								facing_at_frame_start.size()==state.facing.size())
 								{
-								const int32_t source_tile_x=source/input.dim_y;
 								const int32_t target_index=x*input.dim_y+y;
 								state.facing[target_index]=int8_t(
 									facing_after_move(
-										x-source_tile_x,
+										x-source_x,
 										static_cast<visual_facingst>(
 											facing_at_frame_start[source])));
 								facing_target_written[size_t(target_index)]=1;
@@ -900,6 +1086,13 @@ class visual_animation_managerst
 				}
 			}
 
+		// Pausing keeps persistent facing, but drops every in-flight visual transition.
+		void cancel_transitions()
+			{
+			for(viewport_animationst &state:viewports)reset_tracking(state);
+			force_full_redraw=false;
+			}
+
 		uint32_t get_frame_time_ms() const
 			{
 			return frame_time_ms;
@@ -908,6 +1101,40 @@ class visual_animation_managerst
 		uint32_t get_frame_delta_ms() const
 			{
 			return frame_delta_ms;
+			}
+
+		visual_scroll_renderst get_scroll(const void *viewport) const
+			{
+			for(const viewport_animationst &state:viewports)
+				if(state.viewport==viewport)
+					{
+					const auto pending=pending_total(state);
+					return {!state.pending.empty(),state.landed_this_frame,
+						state.abandoned_this_frame,state.landed_shift[0],
+						state.landed_shift[1],pending[0],pending[1],state.follow_candidate};
+					}
+			return {};
+			}
+
+		visual_follow_renderst get_follow(
+			const void *viewport,
+			visual_movement_idst movement_id) const
+			{
+			if(movement_id==no_visual_movement)return {};
+			for(const viewport_animationst &state:viewports)
+				{
+				if(state.viewport!=viewport)continue;
+				for(const movementst &movement:state.movements)
+					if(movement.id==movement_id&&movement_active(movement))
+						{
+						const float remaining=1.0f-movement_progress(movement);
+						return {true,movement.id,
+							(movement.target_x-movement.source_x)*remaining,
+							(movement.target_y-movement.source_y)*remaining};
+						}
+				break;
+				}
+			return {};
 			}
 
 		visual_facingst get_facing(
@@ -962,7 +1189,9 @@ class visual_animation_managerst
 							true,
 							movement.source_x,
 							movement.source_y,
-							movement_progress(movement)
+							movement_progress(movement),
+							false,
+							movement.id
 							};
 						}
 					if(layer==viewport_visual_layer::vehicle||
@@ -988,7 +1217,8 @@ class visual_animation_managerst
 						target_x+companion->source_x-companion->target_x,
 						target_y+companion->source_y-companion->target_y,
 						movement_progress(*companion),
-						true
+						true,
+						companion->id
 						};
 				break;
 				}

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -156,14 +156,36 @@ struct visual_movement_renderst
 	bool inherited=false;
 };
 
+struct visual_icon_rectst
+{
+	float x;
+	float y;
+	float width;
+	float height;
+};
+
+constexpr visual_icon_rectst carried_item_icon_rect(
+	float tile_x,
+	float tile_y,
+	float tile_size)
+{
+	return {
+		tile_x+tile_size*0.05f,
+		tile_y+tile_size*0.2f,
+		tile_size*0.7f,
+		tile_size*0.7f
+		};
+}
+
 inline float animation_progress(
 	uint32_t now_ms,
 	uint32_t start_time_ms,
-	uint32_t duration_ms)
+	uint32_t duration_ms,
+	bool linear=false)
 {
-	const float linear=std::min(
+	const float progress=std::min(
 		1.0f,float(now_ms-start_time_ms)/duration_ms);
-	return linear*linear*(3.0f-2.0f*linear);
+	return linear?progress:progress*progress*(3.0f-2.0f*progress);
 }
 
 inline bool visual_moved_between_tiles(
@@ -221,6 +243,8 @@ class visual_animation_managerst
 		int32_t target_x;
 		int32_t target_y;
 		uint32_t start_time_ms;
+		uint32_t duration_ms;
+		bool historical=false;
 	};
 
 	struct viewport_animationst
@@ -259,9 +283,10 @@ class visual_animation_managerst
 	uint32_t frame_delta_ms=0;
 	bool has_frame=false;
 	bool force_full_redraw=false;
+	bool linear=false;
 	std::vector<viewport_animationst> viewports;
 
-	static constexpr uint32_t movement_duration_ms=100;
+	static constexpr uint32_t movement_duration_ms=150;
 	// Scrolling faster than detection keeps up: give up rather than test ever more prefixes.
 	static constexpr size_t max_pending_shifts=8;
 	// Bounds the wait on a scroll that never lands, so suppression cannot stick forever.
@@ -405,14 +430,32 @@ class visual_animation_managerst
 		return viewports.back();
 		}
 
-	float movement_progress(uint32_t start_time_ms) const
+	float movement_progress(const movementst &movement) const
 		{
 		return animation_progress(
-			frame_time_ms,start_time_ms,movement_duration_ms);
+			frame_time_ms,movement.start_time_ms,
+			linear?movement.duration_ms:movement_duration_ms,linear);
+		}
+
+	bool movement_active(const movementst &movement) const
+		{
+		return !movement.historical&&
+			frame_time_ms-movement.start_time_ms<
+			(linear?movement.duration_ms:movement_duration_ms);
 		}
 
 	public:
 		visual_animation_managerst()=default;
+
+		void set_linear(bool enabled)
+			{
+			linear=enabled;
+			}
+
+		bool is_linear() const
+			{
+			return linear;
+			}
 
 		void begin_frame(uint32_t now_ms)
 			{
@@ -424,7 +467,13 @@ class visual_animation_managerst
 			for(viewport_animationst &state:viewports)
 				{
 				state.seen=false;
-				if(!state.movements.empty())force_full_redraw=true;
+				for(movementst &movement:state.movements)
+					{
+					if(movement.historical)continue;
+					force_full_redraw=true;
+					if(linear&&frame_time_ms-movement.start_time_ms>=movement.duration_ms)
+						movement.historical=true;
+					}
 				}
 			}
 
@@ -725,20 +774,34 @@ class visual_animation_managerst
 							claimed_sources[source]=1;
 							float visual_source_x=float(source/input.dim_y);
 							float visual_source_y=float(source%input.dim_y);
+							const movementst *predecessor=nullptr;
 							for(size_t i=0;i<existing_movement_count;++i)
 								{
 								const movementst &movement=state.movements[i];
 								if(movement.layer!=
-										static_cast<viewport_visual_layer>(layer)||
+									static_cast<viewport_visual_layer>(layer)||
 									movement.target_x!=visual_source_x||
-									movement.target_y!=visual_source_y)continue;
-								const float progress=
-									movement_progress(movement.start_time_ms);
-								visual_source_x=movement.source_x+
-									(movement.target_x-movement.source_x)*progress;
-								visual_source_y=movement.source_y+
-									(movement.target_y-movement.source_y)*progress;
-								break;
+									movement.target_y!=visual_source_y||
+									(linear&&frame_time_ms-movement.start_time_ms>500))continue;
+								if(predecessor==nullptr||
+									frame_time_ms-movement.start_time_ms<
+									frame_time_ms-predecessor->start_time_ms)
+									predecessor=&movement;
+								}
+							uint32_t duration_ms=movement_duration_ms;
+							if(predecessor!=nullptr)
+								{
+								if(movement_active(*predecessor))
+									{
+									const float progress=movement_progress(*predecessor);
+									visual_source_x=predecessor->source_x+
+										(predecessor->target_x-predecessor->source_x)*progress;
+									visual_source_y=predecessor->source_y+
+										(predecessor->target_y-predecessor->source_y)*progress;
+									}
+								if(linear)duration_ms=std::clamp(
+									frame_time_ms-predecessor->start_time_ms,
+									movement_duration_ms,500U);
 								}
 							state.movements.push_back(
 								{
@@ -748,7 +811,8 @@ class visual_animation_managerst
 								visual_source_y,
 								x,
 								y,
-								frame_time_ms
+								frame_time_ms,
+								duration_ms
 								});
 							if(static_cast<viewport_visual_layer>(layer)==
 									viewport_visual_layer::center&&
@@ -785,14 +849,20 @@ class visual_animation_managerst
 				std::remove_if(
 					state.movements.begin(),
 					state.movements.end(),
-					[&](const movementst &movement)
+					[&](movementst &movement)
 						{
 						const size_t layer=static_cast<size_t>(movement.layer);
 						const int32_t target=movement.target_x*input.dim_y+movement.target_y;
 						const int32_t current=input.current[layer][target];
-						return frame_time_ms-movement.start_time_ms>=movement_duration_ms||
-							current==0||
+						const bool invalid=current==0||
 							!visual_layer_matches(movement.layer,current,movement.texpos);
+						if(linear)
+							{
+							if(invalid||frame_time_ms-movement.start_time_ms>=movement.duration_ms)
+								movement.historical=true;
+							return frame_time_ms-movement.start_time_ms>500;
+							}
+						return frame_time_ms-movement.start_time_ms>=movement_duration_ms||invalid;
 						}),
 				state.movements.end());
 			// has_mirrored is recomputed here rather than maintained at every write site.
@@ -811,7 +881,8 @@ class visual_animation_managerst
 					}
 				state.has_mirrored=any_mirrored;
 				}
-			if(!state.movements.empty())force_full_redraw=true;
+			for(const movementst &movement:state.movements)
+				if(movement_active(movement))force_full_redraw=true;
 			}
 
 		void end_frame()
@@ -824,7 +895,8 @@ class visual_animation_managerst
 				viewports.end());
 			for(const viewport_animationst &state:viewports)
 				{
-				if(!state.movements.empty())force_full_redraw=true;
+				for(const movementst &movement:state.movements)
+					if(movement_active(movement))force_full_redraw=true;
 				}
 			}
 
@@ -882,6 +954,7 @@ class visual_animation_managerst
 				bool ambiguous=false;
 				for(const movementst &movement:state.movements)
 					{
+					if(!movement_active(movement))continue;
 					if(movement.layer==layer&&movement.target_x==target_x&&
 						movement.target_y==target_y)
 						{
@@ -889,7 +962,7 @@ class visual_animation_managerst
 							true,
 							movement.source_x,
 							movement.source_y,
-							movement_progress(movement.start_time_ms)
+							movement_progress(movement)
 							};
 						}
 					if(layer==viewport_visual_layer::vehicle||
@@ -902,7 +975,8 @@ class visual_animation_managerst
 							movement.source_x-movement.target_x||
 						companion->source_y-companion->target_y!=
 							movement.source_y-movement.target_y||
-						companion->start_time_ms!=movement.start_time_ms))
+						companion->start_time_ms!=movement.start_time_ms||
+						companion->duration_ms!=movement.duration_ms))
 						ambiguous=true;
 					else if(companion==nullptr)
 						companion=&movement;
@@ -913,7 +987,7 @@ class visual_animation_managerst
 						true,
 						target_x+companion->source_x-companion->target_x,
 						target_y+companion->source_y-companion->target_y,
-						movement_progress(companion->start_time_ms),
+						movement_progress(*companion),
 						true
 						};
 				break;

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -1177,6 +1177,7 @@ class visual_animation_managerst
 			for(const viewport_animationst &state:viewports)
 				{
 				if(state.viewport!=viewport)continue;
+				const auto &descriptor=visual_layer_descriptor(layer);
 				const movementst *companion=nullptr;
 				bool ambiguous=false;
 				for(const movementst &movement:state.movements)
@@ -1196,8 +1197,21 @@ class visual_animation_managerst
 						}
 					if(layer==viewport_visual_layer::vehicle||
 						layer==viewport_visual_layer::center||
-						movement.layer!=viewport_visual_layer::center||
-						std::abs(movement.target_x-target_x)>1||
+						movement.layer!=viewport_visual_layer::center)continue;
+					const bool creature_fragment=
+						descriptor.render_group==visual_render_groupst::main||
+						descriptor.render_group==visual_render_groupst::upper;
+					if(creature_fragment)
+						{
+						if(movement.target_x==target_x+descriptor.center_x&&
+							movement.target_y==target_y+descriptor.center_y)
+							{
+							companion=&movement;
+							break;
+							}
+						continue;
+						}
+					if(std::abs(movement.target_x-target_x)>1||
 						std::abs(movement.target_y-target_y)>1)continue;
 					if(companion!=nullptr&&
 						(companion->source_x-companion->target_x!=


### PR DESCRIPTION
## v0.5.0

This PR prepares the v0.5.0 release.

- adds optional sprite flipping and hauled-item icons
- adds linear movement with adaptive 150-500 ms timing
- adds all on/off for every non-camera flag
- keeps the WIP free camera excluded from all
- updates documentation and regression coverage

## Verification

- development build: plugin compiled and tests passed
- Steam DFHack 53.16-r1.1 build: plugin compiled and tests passed