### PR TITLE
Hash the buffer signature in lanes and reuse detection scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
   stage and engine tile repaints, and (while on) times the render hook split into movement
   detection and drawing. Off by default; the counters cost a few increments per frame.
+- Cheaper idle frames. The per-frame buffer signature now hashes in eight independent
+  FNV-1a lanes instead of one serial chain, and the detection pass reuses its working
+  vectors across frames instead of allocating them per viewport. An idle viewport's sync
+  drops from about 84 to 15 microseconds in the manager benchmark; detection results are
+  unchanged.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
+  stage and engine tile repaints, and (while on) times the render hook split into movement
+  detection and drawing. Off by default; the counters cost a few increments per frame.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,9 @@ add_executable(
     EXCLUDE_FROM_ALL
     test_visual_animation_manager.cpp)
 target_compile_features(smooth-movement-test PRIVATE cxx_std_17)
+
+add_executable(
+    smooth-movement-bench
+    EXCLUDE_FROM_ALL
+    bench_visual_animation_manager.cpp)
+target_compile_features(smooth-movement-bench PRIVATE cxx_std_17)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
 smooth-movement linear on   # use linear easing with adaptive 150–500 ms movement tweens
 smooth-movement hauled on   # show icons for carried boulders, bars, and wood
+smooth-movement stats on    # time the render hook; `smooth-movement stats` prints the numbers
 ```
 
 ## Compatibility

--- a/bench_visual_animation_manager.cpp
+++ b/bench_visual_animation_manager.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+//
+// Timing for the parts of visual_animation_managerst the render hook calls every frame:
+// synchronize_viewport on a fortress-sized viewport, and the per-tile get_movement /
+// get_facing lookups the plugin makes while collecting proxies. Prints microseconds; there
+// are no assertions. Build with `make smooth-movement-bench` (or the compiler line at the
+// top of test_visual_animation_manager.cpp) and run it before and after a change.
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include "visual_animation.h"
+
+namespace {
+
+constexpr int32_t dim_x=100;
+constexpr int32_t dim_y=60;
+constexpr size_t tiles=size_t(dim_x)*size_t(dim_y);
+constexpr size_t layer_count=static_cast<size_t>(viewport_visual_layer::count);
+
+struct viewport_bufferst
+{
+	std::array<std::vector<int32_t>,layer_count> current;
+	std::array<std::vector<int32_t>,layer_count> previous;
+	std::vector<int32_t> background;
+	std::vector<int32_t> background_previous;
+
+	viewport_bufferst()
+		{
+		for(auto &layer:current)layer.assign(tiles,0);
+		for(auto &layer:previous)layer.assign(tiles,0);
+		background.assign(tiles,0);
+		background_previous.assign(tiles,0);
+		for(size_t i=0;i<tiles;++i)background[i]=1000+int32_t(i%7);
+		background_previous=background;
+		}
+
+	// The engine's redraw: current becomes previous, then current is drawn again.
+	void advance()
+		{
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			previous[layer]=current[layer];
+			std::fill(current[layer].begin(),current[layer].end(),0);
+			}
+		background_previous=background;
+		}
+
+	viewport_visual_animation_inputst input() const
+		{
+		viewport_visual_animation_inputst in;
+		in.viewport=this;
+		in.dim_x=dim_x;
+		in.dim_y=dim_y;
+		in.context_revision=1;
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			in.current[layer]=current[layer].data();
+			in.previous[layer]=previous[layer].data();
+			}
+		in.current_background=background.data();
+		in.previous_background=background_previous.data();
+		return in;
+		}
+};
+
+struct creaturest
+{
+	int32_t x;
+	int32_t y;
+	int32_t texpos;
+};
+
+void draw(viewport_bufferst &buffers,const std::vector<creaturest> &creatures)
+{
+	const size_t center=static_cast<size_t>(viewport_visual_layer::center);
+	const size_t right=static_cast<size_t>(viewport_visual_layer::right);
+	for(const creaturest &creature:creatures)
+		{
+		buffers.current[center][size_t(creature.x)*dim_y+size_t(creature.y)]=creature.texpos;
+		if(creature.x+1<dim_x&&creature.texpos%3==0)
+			buffers.current[right][size_t(creature.x+1)*dim_y+size_t(creature.y)]=creature.texpos+1;
+		}
+}
+
+uint64_t now_us()
+{
+	return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+		std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+void run(int32_t creature_count)
+{
+	std::mt19937 rng(7);
+	viewport_bufferst buffers;
+	std::vector<creaturest> creatures;
+	for(int32_t i=0;i<creature_count;++i)
+		creatures.push_back({int32_t(rng()%(dim_x-2))+1,int32_t(rng()%(dim_y-2))+1,100+int32_t(rng()%30)});
+	draw(buffers,creatures);
+
+	visual_animation_managerst manager;
+	uint32_t now_ms=1000;
+	uint64_t sync_us=0,lookup_us=0,facing_us=0;
+	uint64_t active=0;
+	const int frames=300;
+	for(int frame=0;frame<frames;++frame)
+		{
+		// A step every sixth frame: half the creatures move one tile.
+		if(frame%6==0)
+			{
+			buffers.advance();
+			for(creaturest &creature:creatures)
+				{
+				if(rng()%2)continue;
+				const int32_t nx=creature.x+int32_t(rng()%3)-1;
+				const int32_t ny=creature.y+int32_t(rng()%3)-1;
+				if(nx>0&&nx<dim_x-1&&ny>0&&ny<dim_y-1)
+					{
+					creature.x=nx;
+					creature.y=ny;
+					}
+				}
+			draw(buffers,creatures);
+			}
+		manager.begin_frame(now_ms);
+		const uint64_t t0=now_us();
+		manager.synchronize_viewport(buffers.input());
+		manager.end_frame();
+		const uint64_t t1=now_us();
+		// What collect_proxies does: one lookup per drawn tile in every layer.
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			const std::vector<int32_t> &current=buffers.current[layer];
+			for(int32_t x=0;x<dim_x;++x)
+				for(int32_t y=0;y<dim_y;++y)
+					{
+					if(current[size_t(x)*dim_y+size_t(y)]==0)continue;
+					const visual_movement_renderst movement=manager.get_movement(
+						&buffers,static_cast<viewport_visual_layer>(layer),x,y);
+					if(movement.active)++active;
+					}
+			}
+		const uint64_t t2=now_us();
+		// What the resting mirrored pass does: one facing lookup per tile.
+		uint64_t mirrored=0;
+		for(int32_t x=0;x<dim_x;++x)
+			for(int32_t y=0;y<dim_y;++y)
+				if(manager.get_facing(&buffers,x,y)!=native_sprite_facing)++mirrored;
+		const uint64_t t3=now_us();
+		sync_us+=t1-t0;
+		lookup_us+=t2-t1;
+		facing_us+=t3-t2;
+		if(mirrored>tiles)std::printf("unreachable\n");
+		now_ms+=16;
+		}
+	std::printf("%4d creatures: sync %6.1f us  movement lookups %6.1f us  facing lookups %6.1f us  per frame (%.1f active lookups/frame)\n",
+		creature_count,double(sync_us)/frames,double(lookup_us)/frames,double(facing_us)/frames,double(active)/frames);
+}
+
+} // namespace
+
+int main()
+{
+	std::printf("viewport %dx%d, 300 frames of 16 ms, a step every 6 frames\n",dim_x,dim_y);
+	for(int32_t creatures:{10,50,200})run(creatures);
+	return 0;
+}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <set>
@@ -53,6 +54,58 @@ REQUIRE_GLOBAL(window_z);
 namespace {
 
 constexpr const char *plugin_version="0.5.0";
+
+// Frame timing for `smooth-movement stats`. Counting is always on (a few increments per frame);
+// the clock is read only while enabled. Sync covers movement detection across every viewport,
+// render covers everything after it: proxy collection, tile blanking, engine repaints, sprites.
+struct frame_statsst
+{
+	bool enabled=false;
+	uint64_t frames=0;
+	uint64_t painted=0;
+	uint64_t repaints=0;
+	uint64_t sync_us=0;
+	uint64_t sync_max_us=0;
+	uint64_t render_us=0;
+	uint64_t render_max_us=0;
+
+	static uint64_t now_us()
+		{
+		return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+
+	void clear()
+		{
+		frames=painted=repaints=0;
+		sync_us=sync_max_us=render_us=render_max_us=0;
+		}
+
+	void add_sync(uint64_t us)
+		{
+		sync_us+=us;
+		sync_max_us=std::max(sync_max_us,us);
+		}
+
+	void add_render(uint64_t us)
+		{
+		render_us+=us;
+		render_max_us=std::max(render_max_us,us);
+		}
+};
+
+frame_statsst frame_stats;
+
+// Runs a callback when the scope ends, whichever return path is taken.
+template<typename Callback>
+struct scope_guardst
+{
+	Callback callback;
+	explicit scope_guardst(Callback c):callback(std::move(c)){}
+	~scope_guardst(){callback();}
+	scope_guardst(const scope_guardst &)=delete;
+	scope_guardst &operator=(const scope_guardst &)=delete;
+};
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -649,6 +702,13 @@ void with_upper_suppressed(
 		});
 }
 
+// Every engine repaint the plugin asks for goes through here so `stats` can count them.
+void engine_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,int32_t x,int32_t y)
+{
+	++frame_stats.repaints;
+	renderer->update_viewport_tile(vp,x,y);
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -658,7 +718,7 @@ void redraw_viewport_tile(
 {
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto stage=[&]
 		{
 		with_suppressed_visual_layers(
@@ -701,7 +761,7 @@ void draw_interface_only(
 {
 	if(!interface_pass_readable(vp))return;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto without_visuals=[&]
 		{
 		with_suppressed_visual_layers(
@@ -764,7 +824,7 @@ void redraw_above(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		const auto stage=[&]
@@ -890,7 +950,7 @@ SDL_Texture *cached_viewport_texture(
 	// Hauled items are not normally drawn, so stage one tile to populate the renderer cache.
 	scoped_value_restorest<int32_t> staged(vp->screentexpos_background_two[index]);
 	vp->screentexpos_background_two[index]=texpos;
-	renderer->update_viewport_tile(vp,index/vp->dim_y,index%vp->dim_y);
+	engine_repaint(renderer,vp,index/vp->dim_y,index%vp->dim_y);
 	return cached_texture(renderer,texpos);
 }
 
@@ -1324,6 +1384,17 @@ bool has_mirrored_viewport_facing(
 
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
+	++frame_stats.frames;
+	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	uint64_t sync_end_us=frame_start_us;
+	// Runs on every exit, including the early return for frames with nothing to draw.
+	const scope_guardst timing([&]
+		{
+		if(!frame_stats.enabled)return;
+		const uint64_t end_us=frame_statsst::now_us();
+		frame_stats.add_sync(sync_end_us-frame_start_us);
+		frame_stats.add_render(end_us-sync_end_us);
+		});
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
@@ -1342,6 +1413,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
+	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;
@@ -1374,6 +1446,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
 		carried_items.empty()&&previous_coverage.empty())
 		return;
+	++frame_stats.painted;
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
@@ -1524,6 +1597,33 @@ void reset_state()
 	native_follow_id=-1;
 	flip_enabled=false;
 	hauled_enabled=false;
+	frame_stats.clear();
+}
+
+void print_frame_stats(color_ostream &out)
+{
+	const frame_statsst &f=frame_stats;
+	out.print("frame stats: {}\n",f.enabled?"on":"off");
+	if(f.frames==0)
+		{
+		out.print("no frames recorded\n");
+		return;
+		}
+	const auto mean=[](uint64_t total,uint64_t count)
+		{
+		return count==0?0.0:double(total)/double(count);
+		};
+	out.print("frames: {} ({} painted, {:.0f}%)\n",
+		f.frames,f.painted,100.0*mean(f.painted,f.frames));
+	out.print("engine tile repaints: {} ({:.1f} per frame, {:.1f} per painted frame)\n",
+		f.repaints,mean(f.repaints,f.frames),mean(f.repaints,f.painted));
+	if(!f.enabled)return;
+	out.print("sync: mean {:.0f} us, max {} us (every frame)\n",
+		mean(f.sync_us,f.frames),f.sync_max_us);
+	out.print("render: mean {:.0f} us, max {} us (every frame; {:.0f} us per painted frame)\n",
+		mean(f.render_us,f.frames),f.render_max_us,mean(f.render_us,f.painted));
+	out.print("total: mean {:.0f} us per frame\n",
+		mean(f.sync_us+f.render_us,f.frames));
 }
 
 command_result status_command(
@@ -1544,7 +1644,32 @@ command_result status_command(
 			animation_manager.is_linear()?"on":"off");
 		out.print("hauled item icons: {}\n",
 			hauled_enabled?"on":"off");
+		out.print("frame stats: {}\n",
+			frame_stats.enabled?"on":"off");
 		return CR_OK;
+		}
+	if(parameters[0]=="stats")
+		{
+		if(parameters.size()==1)
+			{
+			print_frame_stats(out);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			frame_stats.enabled=parameters[1]=="on";
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats {}\n",parameters[1]);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="reset")
+			{
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats reset\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
 		}
 	if(parameters[0]=="all")
 		{
@@ -1682,7 +1807,8 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
 		"all non-camera flags: all on|off; "
 		"sprite flipping: flip on|off; linear movement: linear on|off; "
-		"hauled item icons: hauled on|off.",
+		"hauled item icons: hauled on|off; "
+		"frame timing: stats [on|off|reset].",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1385,12 +1385,15 @@ bool has_mirrored_viewport_facing(
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	++frame_stats.frames;
-	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	// Read once: the console can flip the flag mid-frame, and a frame timed from its start
+	// only is a frame timed from a zero.
+	const bool timing_enabled=frame_stats.enabled;
+	const uint64_t frame_start_us=timing_enabled?frame_statsst::now_us():0;
 	uint64_t sync_end_us=frame_start_us;
 	// Runs on every exit, including the early return for frames with nothing to draw.
 	const scope_guardst timing([&]
 		{
-		if(!frame_stats.enabled)return;
+		if(!timing_enabled)return;
 		const uint64_t end_us=frame_statsst::now_us();
 		frame_stats.add_sync(sync_end_us-frame_start_us);
 		frame_stats.add_render(end_us-sync_end_us);
@@ -1413,7 +1416,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
-	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
+	if(timing_enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -328,6 +328,12 @@ class visual_animation_managerst
 	bool linear=false;
 	visual_movement_idst next_movement_id=1;
 	std::vector<viewport_animationst> viewports;
+	// Per-frame working storage, kept across frames so a busy frame allocates nothing.
+	std::vector<std::vector<int32_t>> scratch_rebased_previous;
+	std::vector<uint8_t> scratch_claimed_sources;
+	std::vector<int8_t> scratch_facing_at_frame_start;
+	std::vector<uint8_t> scratch_facing_target_written;
+	std::vector<int32_t> scratch_pending_facing_source_clears;
 
 	static constexpr uint32_t movement_duration_ms=150;
 	// Scrolling faster than detection keeps up: give up rather than test ever more prefixes.
@@ -384,30 +390,50 @@ class visual_animation_managerst
 		state.suppress_frames=0;
 		}
 
+	// The signature hashes every tracked buffer each frame, so its speed sets the floor of an
+	// idle frame. One FNV-1a chain is a serial multiply per value; eight independent chains,
+	// each over every eighth value, let the CPU overlap them and finish several times sooner.
+	static constexpr size_t signature_lanes=8;
+
+	static void hash_signature_lanes(
+		uint64_t (&lanes)[signature_lanes],
+		const int32_t *values,
+		int32_t count)
+		{
+		constexpr uint64_t fnv_prime=0x100000001b3ULL;
+		int32_t i=0;
+		for(;i+int32_t(signature_lanes)<=count;i+=int32_t(signature_lanes))
+			for(size_t lane=0;lane<signature_lanes;++lane)
+				lanes[lane]=(lanes[lane]^uint64_t(uint32_t(values[i+int32_t(lane)])))*fnv_prime;
+		for(;i<count;++i)
+			lanes[0]=(lanes[0]^uint64_t(uint32_t(values[i])))*fnv_prime;
+		}
+
 	// Identifies the buffer contents this frame, to tell a redrawn viewport from a repeated one.
 	static uint64_t compute_buffer_signature(const viewport_visual_animation_inputst &input)
 		{
-		// FNV-1a. Only ever compared against the previous frame's value, never stored.
+		// FNV-1a in lanes. Only ever compared against the previous frame's value, never stored.
 		constexpr uint64_t fnv_offset_basis=0xcbf29ce484222325ULL;
 		constexpr uint64_t fnv_prime=0x100000001b3ULL;
-		uint64_t hash=fnv_offset_basis;
+		uint64_t lanes[signature_lanes];
+		for(size_t lane=0;lane<signature_lanes;++lane)
+			lanes[lane]=fnv_offset_basis^uint64_t(lane);
 		const int32_t tile_count=input.dim_x*input.dim_y;
 		if(input.current_background!=nullptr&&input.previous_background!=nullptr)
-			for(int32_t i=0;i<tile_count;++i)
-				{
-				hash=(hash^uint64_t(uint32_t(input.current_background[i])))*fnv_prime;
-				hash=(hash^uint64_t(uint32_t(input.previous_background[i])))*fnv_prime;
-				}
+			{
+			hash_signature_lanes(lanes,input.current_background,tile_count);
+			hash_signature_lanes(lanes,input.previous_background,tile_count);
+			}
 		for(size_t layer=0;layer<input.current.size();++layer)
 			{
 			if(!visual_layer_tracks_own_movement(
 				static_cast<viewport_visual_layer>(layer)))continue;
-			for(int32_t i=0;i<tile_count;++i)
-				{
-				hash=(hash^uint64_t(uint32_t(input.current[layer][i])))*fnv_prime;
-				hash=(hash^uint64_t(uint32_t(input.previous[layer][i])))*fnv_prime;
-				}
+			hash_signature_lanes(lanes,input.current[layer],tile_count);
+			hash_signature_lanes(lanes,input.previous[layer],tile_count);
 			}
+		uint64_t hash=lanes[0];
+		for(size_t lane=1;lane<signature_lanes;++lane)
+			hash=(hash*fnv_prime)^lanes[lane];
 		return hash;
 		}
 
@@ -829,7 +855,7 @@ class visual_animation_managerst
 			// On the landing frame `previous` is still framed on the pre-scroll view.
 			// Rebasing it by the landed delta keeps a creature that walked during the scroll.
 			auto previous_layers=input.previous;
-			std::vector<std::vector<int32_t>> rebased_previous;
+			std::vector<std::vector<int32_t>> &rebased_previous=scratch_rebased_previous;
 			if(translated&&!suppress)
 				{
 				rebased_previous.resize(input.previous.size());
@@ -857,14 +883,19 @@ class visual_animation_managerst
 			if(!suppress)
 				{
 				const int32_t tile_count=input.dim_x*input.dim_y;
-				std::vector<uint8_t> claimed_sources(tile_count);
+				std::vector<uint8_t> &claimed_sources=scratch_claimed_sources;
+				claimed_sources.resize(size_t(tile_count));
 				const size_t existing_movement_count=state.movements.size();
 				// A chained movement's source may already have been rewritten this frame.
-				const std::vector<int8_t> facing_at_frame_start=state.facing;
+				const std::vector<int8_t> &facing_at_frame_start=scratch_facing_at_frame_start;
+				scratch_facing_at_frame_start=state.facing;
 				// Source clears are deferred until every movement this frame is registered.
 				// A source can be another movement's target in the same frame -- a chain.
-				std::vector<uint8_t> facing_target_written;
-				std::vector<int32_t> pending_facing_source_clears;
+				std::vector<uint8_t> &facing_target_written=scratch_facing_target_written;
+				std::vector<int32_t> &pending_facing_source_clears=
+					scratch_pending_facing_source_clears;
+				facing_target_written.clear();
+				pending_facing_source_clears.clear();
 				long double best_follow_distance=std::numeric_limits<long double>::max();
 				if(state.facing.size()==size_t(input.dim_x)*size_t(input.dim_y))
 					facing_target_written.assign(state.facing.size(),0);


### PR DESCRIPTION
Part of the speed series in #20. Depends on PR 0 (#21). Independent of PRs 1 and 2.

## What we get

An idle frame (nothing moving, no mirrored sprites) goes from about 1.17 ms to 0.45 ms in the harness with nine levels; a busy frame from 2.12 to 1.39 ms. Per idle viewport the signature drops from about 84 µs to 15.

## Why we need it

Each frame hashes the current and previous background plus four tracked layers of every viewport to decide whether anything changed. One FNV-1a chain is a dependent multiply per value, so 78 of an idle viewport's 84 µs went to it. Hashing in eight interleaved lanes (every eighth value on its own chain, combined at the end) lets the CPU overlap them. The detection pass also allocated five working vectors per viewport per busy frame; they are now members of the manager and cleared instead.

I left out a "settle the facing only when the buffers changed" gate that was in the same profile: it saves a few microseconds and has a correctness surface, so it is not worth it here.

## Pixels

Identical: byte-for-byte equal trace to `release/v0.5.0` over 1872 harness frames. The lane hash is a different function over the same values, so the signature values change; a missed change needs a 64-bit collision, as before.

https://claude.ai/code/session_01W4Y5M6jkn8uAyLvzkX8spN
