### PR TITLE
Fold a staged tile's shading into its last repaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   zeroed, most tiles of a level below the camera are all zero, and the engine paints nothing
   for them; the render hook now checks that before asking. `smooth-movement stats` reports
   how many repaints were skipped.
+- Fold a staged tile's shading into its last repaint. The engine paints the interface layer
+  last within a repaint, so the tile that the last render group of a viewport touches no
+  longer needs the separate interface-only repaint afterwards; tiles with a designation
+  sprite, a carried item or a top shadow over them keep it. Cuts the repaints of a busy
+  frame by about a fifth more.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
+  stage and engine tile repaints, and (while on) times the render hook split into movement
+  detection and drawing. Off by default; the counters cost a few increments per frame.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
   stage and engine tile repaints, and (while on) times the render hook split into movement
   detection and drawing. Off by default; the counters cost a few increments per frame.
+- Skip engine repaints of tiles that have nothing to paint. With the layers a stage hides
+  zeroed, most tiles of a level below the camera are all zero, and the engine paints nothing
+  for them; the render hook now checks that before asking. `smooth-movement stats` reports
+  how many repaints were skipped.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,9 @@ add_executable(
     EXCLUDE_FROM_ALL
     test_visual_animation_manager.cpp)
 target_compile_features(smooth-movement-test PRIVATE cxx_std_17)
+
+add_executable(
+    smooth-movement-bench
+    EXCLUDE_FROM_ALL
+    bench_visual_animation_manager.cpp)
+target_compile_features(smooth-movement-bench PRIVATE cxx_std_17)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
 smooth-movement linear on   # use linear easing with adaptive 150–500 ms movement tweens
 smooth-movement hauled on   # show icons for carried boulders, bars, and wood
+smooth-movement stats on    # time the render hook; `smooth-movement stats` prints the numbers
 ```
 
 ## Compatibility

--- a/bench_visual_animation_manager.cpp
+++ b/bench_visual_animation_manager.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+//
+// Timing for the parts of visual_animation_managerst the render hook calls every frame:
+// synchronize_viewport on a fortress-sized viewport, and the per-tile get_movement /
+// get_facing lookups the plugin makes while collecting proxies. Prints microseconds; there
+// are no assertions. Build with `make smooth-movement-bench` (or the compiler line at the
+// top of test_visual_animation_manager.cpp) and run it before and after a change.
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include "visual_animation.h"
+
+namespace {
+
+constexpr int32_t dim_x=100;
+constexpr int32_t dim_y=60;
+constexpr size_t tiles=size_t(dim_x)*size_t(dim_y);
+constexpr size_t layer_count=static_cast<size_t>(viewport_visual_layer::count);
+
+struct viewport_bufferst
+{
+	std::array<std::vector<int32_t>,layer_count> current;
+	std::array<std::vector<int32_t>,layer_count> previous;
+	std::vector<int32_t> background;
+	std::vector<int32_t> background_previous;
+
+	viewport_bufferst()
+		{
+		for(auto &layer:current)layer.assign(tiles,0);
+		for(auto &layer:previous)layer.assign(tiles,0);
+		background.assign(tiles,0);
+		background_previous.assign(tiles,0);
+		for(size_t i=0;i<tiles;++i)background[i]=1000+int32_t(i%7);
+		background_previous=background;
+		}
+
+	// The engine's redraw: current becomes previous, then current is drawn again.
+	void advance()
+		{
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			previous[layer]=current[layer];
+			std::fill(current[layer].begin(),current[layer].end(),0);
+			}
+		background_previous=background;
+		}
+
+	viewport_visual_animation_inputst input() const
+		{
+		viewport_visual_animation_inputst in;
+		in.viewport=this;
+		in.dim_x=dim_x;
+		in.dim_y=dim_y;
+		in.context_revision=1;
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			in.current[layer]=current[layer].data();
+			in.previous[layer]=previous[layer].data();
+			}
+		in.current_background=background.data();
+		in.previous_background=background_previous.data();
+		return in;
+		}
+};
+
+struct creaturest
+{
+	int32_t x;
+	int32_t y;
+	int32_t texpos;
+};
+
+void draw(viewport_bufferst &buffers,const std::vector<creaturest> &creatures)
+{
+	const size_t center=static_cast<size_t>(viewport_visual_layer::center);
+	const size_t right=static_cast<size_t>(viewport_visual_layer::right);
+	for(const creaturest &creature:creatures)
+		{
+		buffers.current[center][size_t(creature.x)*dim_y+size_t(creature.y)]=creature.texpos;
+		if(creature.x+1<dim_x&&creature.texpos%3==0)
+			buffers.current[right][size_t(creature.x+1)*dim_y+size_t(creature.y)]=creature.texpos+1;
+		}
+}
+
+uint64_t now_us()
+{
+	return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+		std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+void run(int32_t creature_count)
+{
+	std::mt19937 rng(7);
+	viewport_bufferst buffers;
+	std::vector<creaturest> creatures;
+	for(int32_t i=0;i<creature_count;++i)
+		creatures.push_back({int32_t(rng()%(dim_x-2))+1,int32_t(rng()%(dim_y-2))+1,100+int32_t(rng()%30)});
+	draw(buffers,creatures);
+
+	visual_animation_managerst manager;
+	uint32_t now_ms=1000;
+	uint64_t sync_us=0,lookup_us=0,facing_us=0;
+	uint64_t active=0;
+	const int frames=300;
+	for(int frame=0;frame<frames;++frame)
+		{
+		// A step every sixth frame: half the creatures move one tile.
+		if(frame%6==0)
+			{
+			buffers.advance();
+			for(creaturest &creature:creatures)
+				{
+				if(rng()%2)continue;
+				const int32_t nx=creature.x+int32_t(rng()%3)-1;
+				const int32_t ny=creature.y+int32_t(rng()%3)-1;
+				if(nx>0&&nx<dim_x-1&&ny>0&&ny<dim_y-1)
+					{
+					creature.x=nx;
+					creature.y=ny;
+					}
+				}
+			draw(buffers,creatures);
+			}
+		manager.begin_frame(now_ms);
+		const uint64_t t0=now_us();
+		manager.synchronize_viewport(buffers.input());
+		manager.end_frame();
+		const uint64_t t1=now_us();
+		// What collect_proxies does: one lookup per drawn tile in every layer.
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			const std::vector<int32_t> &current=buffers.current[layer];
+			for(int32_t x=0;x<dim_x;++x)
+				for(int32_t y=0;y<dim_y;++y)
+					{
+					if(current[size_t(x)*dim_y+size_t(y)]==0)continue;
+					const visual_movement_renderst movement=manager.get_movement(
+						&buffers,static_cast<viewport_visual_layer>(layer),x,y);
+					if(movement.active)++active;
+					}
+			}
+		const uint64_t t2=now_us();
+		// What the resting mirrored pass does: one facing lookup per tile.
+		uint64_t mirrored=0;
+		for(int32_t x=0;x<dim_x;++x)
+			for(int32_t y=0;y<dim_y;++y)
+				if(manager.get_facing(&buffers,x,y)!=native_sprite_facing)++mirrored;
+		const uint64_t t3=now_us();
+		sync_us+=t1-t0;
+		lookup_us+=t2-t1;
+		facing_us+=t3-t2;
+		if(mirrored>tiles)std::printf("unreachable\n");
+		now_ms+=16;
+		}
+	std::printf("%4d creatures: sync %6.1f us  movement lookups %6.1f us  facing lookups %6.1f us  per frame (%.1f active lookups/frame)\n",
+		creature_count,double(sync_us)/frames,double(lookup_us)/frames,double(facing_us)/frames,double(active)/frames);
+}
+
+} // namespace
+
+int main()
+{
+	std::printf("viewport %dx%d, 300 frames of 16 ms, a step every 6 frames\n",dim_x,dim_y);
+	for(int32_t creatures:{10,50,200})run(creatures);
+	return 0;
+}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <set>
@@ -53,6 +54,58 @@ REQUIRE_GLOBAL(window_z);
 namespace {
 
 constexpr const char *plugin_version="0.5.0";
+
+// Frame timing for `smooth-movement stats`. Counting is always on (a few increments per frame);
+// the clock is read only while enabled. Sync covers movement detection across every viewport,
+// render covers everything after it: proxy collection, tile blanking, engine repaints, sprites.
+struct frame_statsst
+{
+	bool enabled=false;
+	uint64_t frames=0;
+	uint64_t painted=0;
+	uint64_t repaints=0;
+	uint64_t sync_us=0;
+	uint64_t sync_max_us=0;
+	uint64_t render_us=0;
+	uint64_t render_max_us=0;
+
+	static uint64_t now_us()
+		{
+		return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+
+	void clear()
+		{
+		frames=painted=repaints=0;
+		sync_us=sync_max_us=render_us=render_max_us=0;
+		}
+
+	void add_sync(uint64_t us)
+		{
+		sync_us+=us;
+		sync_max_us=std::max(sync_max_us,us);
+		}
+
+	void add_render(uint64_t us)
+		{
+		render_us+=us;
+		render_max_us=std::max(render_max_us,us);
+		}
+};
+
+frame_statsst frame_stats;
+
+// Runs a callback when the scope ends, whichever return path is taken.
+template<typename Callback>
+struct scope_guardst
+{
+	Callback callback;
+	explicit scope_guardst(Callback c):callback(std::move(c)){}
+	~scope_guardst(){callback();}
+	scope_guardst(const scope_guardst &)=delete;
+	scope_guardst &operator=(const scope_guardst &)=delete;
+};
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -649,6 +702,13 @@ void with_upper_suppressed(
 		});
 }
 
+// Every engine repaint the plugin asks for goes through here so `stats` can count them.
+void engine_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,int32_t x,int32_t y)
+{
+	++frame_stats.repaints;
+	renderer->update_viewport_tile(vp,x,y);
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -658,7 +718,7 @@ void redraw_viewport_tile(
 {
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto stage=[&]
 		{
 		with_suppressed_visual_layers(
@@ -701,7 +761,7 @@ void draw_interface_only(
 {
 	if(!interface_pass_readable(vp))return;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto without_visuals=[&]
 		{
 		with_suppressed_visual_layers(
@@ -764,7 +824,7 @@ void redraw_above(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		const auto stage=[&]
@@ -890,7 +950,7 @@ SDL_Texture *cached_viewport_texture(
 	// Hauled items are not normally drawn, so stage one tile to populate the renderer cache.
 	scoped_value_restorest<int32_t> staged(vp->screentexpos_background_two[index]);
 	vp->screentexpos_background_two[index]=texpos;
-	renderer->update_viewport_tile(vp,index/vp->dim_y,index%vp->dim_y);
+	engine_repaint(renderer,vp,index/vp->dim_y,index%vp->dim_y);
 	return cached_texture(renderer,texpos);
 }
 
@@ -1324,6 +1384,17 @@ bool has_mirrored_viewport_facing(
 
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
+	++frame_stats.frames;
+	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	uint64_t sync_end_us=frame_start_us;
+	// Runs on every exit, including the early return for frames with nothing to draw.
+	const scope_guardst timing([&]
+		{
+		if(!frame_stats.enabled)return;
+		const uint64_t end_us=frame_statsst::now_us();
+		frame_stats.add_sync(sync_end_us-frame_start_us);
+		frame_stats.add_render(end_us-sync_end_us);
+		});
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
@@ -1342,6 +1413,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
+	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;
@@ -1374,6 +1446,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
 		carried_items.empty()&&previous_coverage.empty())
 		return;
+	++frame_stats.painted;
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
@@ -1524,6 +1597,33 @@ void reset_state()
 	native_follow_id=-1;
 	flip_enabled=false;
 	hauled_enabled=false;
+	frame_stats.clear();
+}
+
+void print_frame_stats(color_ostream &out)
+{
+	const frame_statsst &f=frame_stats;
+	out.print("frame stats: {}\n",f.enabled?"on":"off");
+	if(f.frames==0)
+		{
+		out.print("no frames recorded\n");
+		return;
+		}
+	const auto mean=[](uint64_t total,uint64_t count)
+		{
+		return count==0?0.0:double(total)/double(count);
+		};
+	out.print("frames: {} ({} painted, {:.0f}%)\n",
+		f.frames,f.painted,100.0*mean(f.painted,f.frames));
+	out.print("engine tile repaints: {} ({:.1f} per frame, {:.1f} per painted frame)\n",
+		f.repaints,mean(f.repaints,f.frames),mean(f.repaints,f.painted));
+	if(!f.enabled)return;
+	out.print("sync: mean {:.0f} us, max {} us (every frame)\n",
+		mean(f.sync_us,f.frames),f.sync_max_us);
+	out.print("render: mean {:.0f} us, max {} us (every frame; {:.0f} us per painted frame)\n",
+		mean(f.render_us,f.frames),f.render_max_us,mean(f.render_us,f.painted));
+	out.print("total: mean {:.0f} us per frame\n",
+		mean(f.sync_us+f.render_us,f.frames));
 }
 
 command_result status_command(
@@ -1544,7 +1644,32 @@ command_result status_command(
 			animation_manager.is_linear()?"on":"off");
 		out.print("hauled item icons: {}\n",
 			hauled_enabled?"on":"off");
+		out.print("frame stats: {}\n",
+			frame_stats.enabled?"on":"off");
 		return CR_OK;
+		}
+	if(parameters[0]=="stats")
+		{
+		if(parameters.size()==1)
+			{
+			print_frame_stats(out);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			frame_stats.enabled=parameters[1]=="on";
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats {}\n",parameters[1]);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="reset")
+			{
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats reset\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
 		}
 	if(parameters[0]=="all")
 		{
@@ -1682,7 +1807,8 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
 		"all non-camera flags: all on|off; "
 		"sprite flipping: flip on|off; linear movement: linear on|off; "
-		"hauled item icons: hauled on|off.",
+		"hauled item icons: hauled on|off; "
+		"frame timing: stats [on|off|reset].",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1385,12 +1385,15 @@ bool has_mirrored_viewport_facing(
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	++frame_stats.frames;
-	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	// Read once: the console can flip the flag mid-frame, and a frame timed from its start
+	// only is a frame timed from a zero.
+	const bool timing_enabled=frame_stats.enabled;
+	const uint64_t frame_start_us=timing_enabled?frame_statsst::now_us():0;
 	uint64_t sync_end_us=frame_start_us;
 	// Runs on every exit, including the early return for frames with nothing to draw.
 	const scope_guardst timing([&]
 		{
-		if(!frame_stats.enabled)return;
+		if(!timing_enabled)return;
 		const uint64_t end_us=frame_statsst::now_us();
 		frame_stats.add_sync(sync_end_us-frame_start_us);
 		frame_stats.add_render(end_us-sync_end_us);
@@ -1413,7 +1416,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
-	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
+	if(timing_enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -621,6 +621,15 @@ struct viewport_renderst
 	df::graphic_viewportst *viewport;
 	std::vector<render_proxyst> proxies;
 	render_coveragest coverage;
+	// Per tile, indexed like the buffers, whether the shading (the interface layer) rode on a
+	// repaint this frame, so the interface-only pass can leave the tile alone.
+	std::vector<uint8_t> shaded;
+	// Per tile, whether something is drawn over it after its last repaint: a designation
+	// sprite or a carried item. Its shading then waits for the interface-only pass.
+	std::vector<uint8_t> drawn_over;
+	// Per tile, the sprite group whose repaint above it can carry the shading, or no_group.
+	std::vector<uint8_t> shading_group;
+	static constexpr uint8_t no_group=0xff;
 };
 
 constexpr uint16_t visual_layer_bit(viewport_visual_layer layer)
@@ -755,9 +764,16 @@ void staged_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,in
 	engine_repaint(renderer,vp,x,y);
 }
 
+// The interface-only pass paints the top shadow again as well, over everything drawn on the
+// tile. A tile with a top shadow keeps that pass, so its shading never rides on a repaint.
+bool shadow_keeps_interface_pass(const df::graphic_viewportst *vp,int32_t index)
+{
+	return vp->screentexpos_top_shadow!=nullptr&&vp->screentexpos_top_shadow[index]!=0;
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
-	const viewport_renderst &viewport,
+	viewport_renderst &viewport,
 	int32_t x,
 	int32_t y,
 	bool defer_interface)
@@ -773,6 +789,14 @@ void redraw_viewport_tile(
 		};
 	// The interface layer is the shading for levels below the camera.
 	// A staged tile has a sprite drawn over it afterwards, so draw_interface_only places it instead.
+	// Unless nothing gets drawn over the tile: then this repaint is its last, and the engine
+	// paints the interface layer last within a repaint, so the shading can ride along.
+	if(defer_interface&&!viewport.coverage.all.count({x,y})&&
+		!viewport.drawn_over[size_t(index)]&&!shadow_keeps_interface_pass(vp,index))
+		{
+		defer_interface=false;
+		viewport.shaded[size_t(index)]=1;
+		}
 	if(!defer_interface||vp->screentexpos_interface==nullptr)stage();
 	else with_zeroed_values(stage,vp->screentexpos_interface[index]);
 }
@@ -836,14 +860,14 @@ void draw_interface_only(
 
 void redraw_world_tile(
 	df::renderer_2d_base *renderer,
-	const std::vector<viewport_renderst> &viewports,
+	std::vector<viewport_renderst> &viewports,
 	const tile_coveragest &staged,
 	int32_t x,
 	int32_t y)
 {
 	// The stage pass repaints everything above the lowest across the staged tiles, after the proxies.
 	const bool staged_tile=staged.count({x,y})!=0;
-	for(const viewport_renderst &viewport:viewports)
+	for(viewport_renderst &viewport:viewports)
 		{
 		if(inside_clip(viewport.viewport,x,y))
 			redraw_viewport_tile(renderer,viewport,x,y,staged_tile);
@@ -867,7 +891,8 @@ void redraw_above(
 	int32_t x,
 	int32_t y,
 	visual_render_groupst group,
-	const std::unordered_map<int32_t,uint16_t> &selected)
+	const std::unordered_map<int32_t,uint16_t> &selected,
+	bool with_interface)
 {
 	const int32_t index=x*vp->dim_y+y;
 	const auto redraw=[&]{staged_repaint(renderer,vp,x,y);};
@@ -882,8 +907,9 @@ void redraw_above(
 				redraw);
 			};
 		// The interface layer sits above every group, so each group's redraw would paint it again.
-		// draw_interface_only places it once, after the sprites.
-		if(vp->screentexpos_interface==nullptr)stage();
+		// It rides on the repaint above the tile's last group when nothing is drawn over the tile
+		// afterwards; otherwise draw_interface_only places it once, after the sprites.
+		if(with_interface||vp->screentexpos_interface==nullptr)stage();
 		else with_zeroed_values(stage,vp->screentexpos_interface[index]);
 		};
 	if(group==visual_render_groupst::item||group==visual_render_groupst::vehicle)
@@ -1346,7 +1372,9 @@ std::vector<viewport_renderst> collect_viewport_renders(
 	renders.reserve(viewports.size());
 	for(df::graphic_viewportst *vp:viewports)
 		{
-		viewport_renderst render={vp,collect_proxies(renderer,vp),{}};
+		viewport_renderst render;
+		render.viewport=vp;
+		render.proxies=collect_proxies(renderer,vp);
 		render.coverage=collect_coverage(render.proxies,vp->dim_y);
 		renders.push_back(std::move(render));
 		}
@@ -1363,26 +1391,50 @@ tile_coveragest collect_viewport_coverage(
 	return coverage;
 }
 
+// For every tile with a repaint above a sprite group, the last such group: its repaint is the
+// tile's last, so the shading can ride on it, unless something is drawn over the tile later.
+void collect_shading_groups(viewport_renderst &viewport)
+{
+	df::graphic_viewportst *vp=viewport.viewport;
+	for(size_t index=0;index<viewport.coverage.groups.size();++index)
+		{
+		if(static_cast<visual_render_groupst>(index)==visual_render_groupst::designation)
+			continue;
+		for(const auto &[x,y]:viewport.coverage.groups[index])
+			{
+			const size_t tile=size_t(x*vp->dim_y+y);
+			if(!viewport.drawn_over[tile]&&!shadow_keeps_interface_pass(vp,int32_t(tile)))
+				viewport.shading_group[tile]=uint8_t(index);
+			}
+		}
+}
+
 void draw_interpolation_stages(
 	df::renderer_2d_base *renderer,
-	df::graphic_viewportst *vp,
-	const std::vector<render_proxyst> &proxies,
-	const render_coveragest &coverage)
+	viewport_renderst &viewport)
 {
+	df::graphic_viewportst *vp=viewport.viewport;
+	const render_coveragest &coverage=viewport.coverage;
+	collect_shading_groups(viewport);
 	for(size_t index=0;index<coverage.groups.size();++index)
 		{
 		const auto group=static_cast<visual_render_groupst>(index);
-		for(const render_proxyst &proxy:proxies)
+		for(const render_proxyst &proxy:viewport.proxies)
 			if(visual_render_group(proxy.layer)==group)draw_proxy(renderer,proxy);
 		if(group==visual_render_groupst::designation)continue;
 		for(const auto &[x,y]:coverage.groups[index])
-			redraw_above(renderer,vp,x,y,group,coverage.selected);
+			{
+			const size_t tile=size_t(x*vp->dim_y+y);
+			const bool with_interface=viewport.shading_group[tile]==uint8_t(index);
+			if(with_interface)viewport.shaded[tile]=1;
+			redraw_above(renderer,vp,x,y,group,coverage.selected,with_interface);
+			}
 		}
 }
 
 void redraw_viewport_tiles(
 	df::renderer_2d_base *renderer,
-	const viewport_renderst &viewport,
+	viewport_renderst &viewport,
 	const tile_coveragest &coverage)
 {
 	df::graphic_viewportst *vp=viewport.viewport;
@@ -1395,7 +1447,7 @@ void redraw_viewport_tiles(
 
 void draw_viewport_interpolation_stages(
 	df::renderer_2d_base *renderer,
-	const std::vector<viewport_renderst> &viewports,
+	std::vector<viewport_renderst> &viewports,
 	const tile_coveragest &coverage,
 	const std::vector<carried_item_proxyst> &carried_items)
 {
@@ -1404,17 +1456,18 @@ void draw_viewport_interpolation_stages(
 		// A lower z-level's proxy must be covered by the next viewport's fog and terrain.
 		// Reapply that viewport before its own proxies, matching DF's lower-to-main draw order.
 		if(index>0)redraw_viewport_tiles(renderer,viewports[index],coverage);
-		const viewport_renderst &viewport=viewports[index];
-		draw_interpolation_stages(
-			renderer,viewport.viewport,viewport.proxies,viewport.coverage);
+		viewport_renderst &viewport=viewports[index];
+		draw_interpolation_stages(renderer,viewport);
 		if(index+1==viewports.size())
 			for(const carried_item_proxyst &proxy:carried_items)
 				draw_carried_item_proxy(renderer,proxy);
 		// A viewport shades everything drawn beneath it, so this covers every staged tile.
 		// Restricting it to the tiles this viewport has sprites on would not deepen with distance.
+		// A tile whose shading already rode on its last repaint is done.
 		for(const auto &[x,y]:coverage)
 			{
-			if(inside_clip(viewport.viewport,x,y))
+			if(inside_clip(viewport.viewport,x,y)&&
+				!viewport.shaded[size_t(x*viewport.viewport->dim_y+y)])
 				draw_interface_only(renderer,viewport.viewport,x,y);
 			}
 		}
@@ -1499,6 +1552,25 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
+	// Designation sprites have no repaint above them, and carried items are drawn last over
+	// the main viewport: the shading of the tiles they cover waits for the interface-only pass.
+	for(viewport_renderst &render:viewport_renders)
+		{
+		const size_t tile_count=size_t(render.viewport->dim_x)*size_t(render.viewport->dim_y);
+		render.shaded.assign(tile_count,0);
+		render.drawn_over.assign(tile_count,0);
+		render.shading_group.assign(tile_count,viewport_renderst::no_group);
+		for(const auto &[x,y]:render.coverage.groups[
+				static_cast<size_t>(visual_render_groupst::designation)])
+			render.drawn_over[size_t(x*render.viewport->dim_y+y)]=1;
+		}
+	if(!viewport_renders.empty())
+		{
+		viewport_renderst &main_render=viewport_renders.back();
+		for(const carried_item_proxyst &proxy:carried_items)
+			for(const auto &[x,y]:proxy.coverage)
+				main_render.drawn_over[size_t(x*main_render.viewport->dim_y+y)]=1;
+		}
 	tile_coveragest coverage=collect_viewport_coverage(viewport_renders);
 	for(const carried_item_proxyst &proxy:carried_items)
 		coverage.insert(proxy.coverage.begin(),proxy.coverage.end());

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -64,6 +64,7 @@ struct frame_statsst
 	uint64_t frames=0;
 	uint64_t painted=0;
 	uint64_t repaints=0;
+	uint64_t blank_repaints_skipped=0;
 	uint64_t sync_us=0;
 	uint64_t sync_max_us=0;
 	uint64_t render_us=0;
@@ -77,7 +78,7 @@ struct frame_statsst
 
 	void clear()
 		{
-		frames=painted=repaints=0;
+		frames=painted=repaints=blank_repaints_skipped=0;
 		sync_us=sync_max_us=render_us=render_max_us=0;
 		}
 
@@ -709,6 +710,51 @@ void engine_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,in
 	renderer->update_viewport_tile(vp,x,y);
 }
 
+// Whether a repaint of the tile would paint anything: the engine draws only the buffers that
+// hold a texture or flag, so a tile whose buffers are all zero paints nothing. Most tiles of a
+// level below the camera are like that, and so is any tile once the layers a stage hides are
+// zeroed. Read inside the suppressed context, right before the repaint it can save.
+bool tile_paints_nothing(const df::graphic_viewportst *vp,int32_t index)
+{
+	const auto zero=[index](const auto *buffer){return buffer==nullptr||buffer[index]==0;};
+	return zero(vp->screentexpos_background)&&
+		zero(vp->screentexpos_floor_flag)&&
+		zero(vp->screentexpos_background_two)&&
+		zero(vp->screentexpos_liquid_flag)&&
+		zero(vp->screentexpos_spatter_flag)&&
+		zero(vp->screentexpos_spatter)&&
+		zero(vp->screentexpos_ramp_flag)&&
+		zero(vp->screentexpos_shadow_flag)&&
+		zero(vp->screentexpos_building_one)&&
+		zero(vp->screentexpos_item)&&
+		zero(vp->screentexpos_vehicle)&&
+		zero(vp->screentexpos_vermin)&&
+		zero(vp->screentexpos_left_creature)&&
+		zero(vp->screentexpos)&&
+		zero(vp->screentexpos_right_creature)&&
+		zero(vp->screentexpos_building_two)&&
+		zero(vp->screentexpos_projectile)&&
+		zero(vp->screentexpos_high_flow)&&
+		zero(vp->screentexpos_top_shadow)&&
+		zero(vp->screentexpos_signpost)&&
+		zero(vp->screentexpos_upleft_creature)&&
+		zero(vp->screentexpos_up_creature)&&
+		zero(vp->screentexpos_upright_creature)&&
+		zero(vp->screentexpos_designation)&&
+		zero(vp->screentexpos_interface);
+}
+
+// A staged repaint: skipped when the tile, with the stage's layers hidden, has nothing to paint.
+void staged_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,int32_t x,int32_t y)
+{
+	if(tile_paints_nothing(vp,x*vp->dim_y+y))
+		{
+		++frame_stats.blank_repaints_skipped;
+		return;
+		}
+	engine_repaint(renderer,vp,x,y);
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -718,7 +764,7 @@ void redraw_viewport_tile(
 {
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
+	const auto redraw=[&]{staged_repaint(renderer,vp,x,y);};
 	const auto stage=[&]
 		{
 		with_suppressed_visual_layers(
@@ -761,7 +807,7 @@ void draw_interface_only(
 {
 	if(!interface_pass_readable(vp))return;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
+	const auto redraw=[&]{staged_repaint(renderer,vp,x,y);};
 	const auto without_visuals=[&]
 		{
 		with_suppressed_visual_layers(
@@ -824,7 +870,7 @@ void redraw_above(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
+	const auto redraw=[&]{staged_repaint(renderer,vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		const auto stage=[&]
@@ -1620,6 +1666,8 @@ void print_frame_stats(color_ostream &out)
 		f.frames,f.painted,100.0*mean(f.painted,f.frames));
 	out.print("engine tile repaints: {} ({:.1f} per frame, {:.1f} per painted frame)\n",
 		f.repaints,mean(f.repaints,f.frames),mean(f.repaints,f.painted));
+	out.print("repaints skipped for having nothing to paint: {} ({:.1f} per frame)\n",
+		f.blank_repaints_skipped,mean(f.blank_repaints_skipped,f.frames));
 	if(!f.enabled)return;
 	out.print("sync: mean {:.0f} us, max {} us (every frame)\n",
 		mean(f.sync_us,f.frames),f.sync_max_us);


### PR DESCRIPTION
Part of the speed series in #20, second series. Depends on PR 2 (#23).

## What we get

Engine repaints per busy frame go from about 860 (PR 2) to 675 in the harness with nine levels; idle-with-mirrored-sprites from 261 to 197. Roughly one repaint fewer per covered tile per viewport.

## Why we need it

The interface layer carries the shading of levels below the camera. A staged tile gets its sprites drawn after the repaint, and a sprite would cover the shading, so today every covered tile gets a second, interface-only repaint after all its groups. But the engine paints the interface layer last within a repaint, so when the last render group that touches a tile repaints it, nothing is drawn over it afterwards and the shading can ride on that repaint. Tiles that a designation sprite or a carried item is drawn over keep the separate pass, as do tiles a viewport touches without repainting, and tiles with a top shadow, because the interface-only pass paints the top shadow over the sprites too. Three per-tile byte vectors on the viewport render (which group paints last, drawn-over, already shaded) carry the bookkeeping.

## Assumption

That the engine paints the interface layer last within a tile repaint. My fork has run on this for a while; not re-measured on this codebase.

## What changes on screen

The order of operations, not the result: the shading is painted with the last repaint instead of after it. Verified with a per-cell oracle over 1872 harness frames (mirrored sprites, moving designations, hauled boulders, shading and top shadows on every level): for every 32x32 cell, the sequence of non-blank repaints, interface paints, sprite copies and fills is identical to PR 2 (0 of 3537 cells differ). Sabotaged builds that fold under a designation or a carried item are caught by the oracle (6 and 237 differing cells), and so was an earlier version of this branch that folded under top shadows (1352 cells).

https://claude.ai/code/session_01W4Y5M6jkn8uAyLvzkX8spN
