### PR TITLE
Drop the re-blank of the tiles a sprite covered last frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   layer. Fragments find their anchor through a per-tile table, and resting mirrored
   creatures come from a list the manager keeps, so the collector no longer touches
   every tile of the viewport each frame. Same sprites, same order, same pixels.
+- Flat coverage bookkeeping and one blank-out fill per frame. The tiles a frame touches are
+  tracked in a per-tile flag grid with a mark list instead of ordered sets of pairs, the
+  per-tile selected-layer mask is a vector indexed like the buffers, and the tiles blanked
+  before repainting go to SDL in a single `SDL_RenderFillRects` call. Same repaints and
+  draws in the same order; less time between them.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   per-tile selected-layer mask is a vector indexed like the buffers, and the tiles blanked
   before repainting go to SDL in a single `SDL_RenderFillRects` call. Same repaints and
   draws in the same order; less time between them.
+- Stop re-blanking and repainting the tiles a sprite covered the frame before. The engine
+  repaints every viewport tile each frame before the render hook runs, so those tiles are
+  already clean; only the tiles this frame's sprites touch are blanked. Drops the
+  previous-coverage set and the pan tracking that only existed to discard it.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
   stage and engine tile repaints, and (while on) times the render hook split into movement
   detection and drawing. Off by default; the counters cost a few increments per frame.
+- Look movements up by tile instead of scanning the movement list, and collect sprite
+  proxies from the tiles that have movements instead of sweeping every tile of every
+  layer. Fragments find their anchor through a per-tile table, and resting mirrored
+  creatures come from a list the manager keeps, so the collector no longer touches
+  every tile of the viewport each frame. Same sprites, same order, same pixels.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `smooth-movement stats [on|off|reset]`: counts frames, frames that reached the draw
+  stage and engine tile repaints, and (while on) times the render hook split into movement
+  detection and drawing. Off by default; the counters cost a few increments per frame.
 - Set smoothstep movement tweens to 150 ms. Add optional linear easing with
   adaptive 150–500 ms durations based on the cadence between consecutive steps
   (`smooth-movement linear on`) and icons for boulders, bars, and wood hauled by units

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,3 +7,9 @@ add_executable(
     EXCLUDE_FROM_ALL
     test_visual_animation_manager.cpp)
 target_compile_features(smooth-movement-test PRIVATE cxx_std_17)
+
+add_executable(
+    smooth-movement-bench
+    EXCLUDE_FROM_ALL
+    bench_visual_animation_manager.cpp)
+target_compile_features(smooth-movement-bench PRIVATE cxx_std_17)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ smooth-movement flip on     # enable sprites flip
 smooth-movement camera on   # enable the free camera
 smooth-movement linear on   # use linear easing with adaptive 150–500 ms movement tweens
 smooth-movement hauled on   # show icons for carried boulders, bars, and wood
+smooth-movement stats on    # time the render hook; `smooth-movement stats` prints the numbers
 ```
 
 ## Compatibility

--- a/bench_visual_animation_manager.cpp
+++ b/bench_visual_animation_manager.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+//
+// Timing for the parts of visual_animation_managerst the render hook calls every frame:
+// synchronize_viewport on a fortress-sized viewport, and the per-tile get_movement /
+// get_facing lookups the plugin makes while collecting proxies. Prints microseconds; there
+// are no assertions. Build with `make smooth-movement-bench` (or the compiler line at the
+// top of test_visual_animation_manager.cpp) and run it before and after a change.
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include "visual_animation.h"
+
+namespace {
+
+constexpr int32_t dim_x=100;
+constexpr int32_t dim_y=60;
+constexpr size_t tiles=size_t(dim_x)*size_t(dim_y);
+constexpr size_t layer_count=static_cast<size_t>(viewport_visual_layer::count);
+
+struct viewport_bufferst
+{
+	std::array<std::vector<int32_t>,layer_count> current;
+	std::array<std::vector<int32_t>,layer_count> previous;
+	std::vector<int32_t> background;
+	std::vector<int32_t> background_previous;
+
+	viewport_bufferst()
+		{
+		for(auto &layer:current)layer.assign(tiles,0);
+		for(auto &layer:previous)layer.assign(tiles,0);
+		background.assign(tiles,0);
+		background_previous.assign(tiles,0);
+		for(size_t i=0;i<tiles;++i)background[i]=1000+int32_t(i%7);
+		background_previous=background;
+		}
+
+	// The engine's redraw: current becomes previous, then current is drawn again.
+	void advance()
+		{
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			previous[layer]=current[layer];
+			std::fill(current[layer].begin(),current[layer].end(),0);
+			}
+		background_previous=background;
+		}
+
+	viewport_visual_animation_inputst input() const
+		{
+		viewport_visual_animation_inputst in;
+		in.viewport=this;
+		in.dim_x=dim_x;
+		in.dim_y=dim_y;
+		in.context_revision=1;
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			in.current[layer]=current[layer].data();
+			in.previous[layer]=previous[layer].data();
+			}
+		in.current_background=background.data();
+		in.previous_background=background_previous.data();
+		return in;
+		}
+};
+
+struct creaturest
+{
+	int32_t x;
+	int32_t y;
+	int32_t texpos;
+};
+
+void draw(viewport_bufferst &buffers,const std::vector<creaturest> &creatures)
+{
+	const size_t center=static_cast<size_t>(viewport_visual_layer::center);
+	const size_t right=static_cast<size_t>(viewport_visual_layer::right);
+	for(const creaturest &creature:creatures)
+		{
+		buffers.current[center][size_t(creature.x)*dim_y+size_t(creature.y)]=creature.texpos;
+		if(creature.x+1<dim_x&&creature.texpos%3==0)
+			buffers.current[right][size_t(creature.x+1)*dim_y+size_t(creature.y)]=creature.texpos+1;
+		}
+}
+
+uint64_t now_us()
+{
+	return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+		std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+void run(int32_t creature_count)
+{
+	std::mt19937 rng(7);
+	viewport_bufferst buffers;
+	std::vector<creaturest> creatures;
+	for(int32_t i=0;i<creature_count;++i)
+		creatures.push_back({int32_t(rng()%(dim_x-2))+1,int32_t(rng()%(dim_y-2))+1,100+int32_t(rng()%30)});
+	draw(buffers,creatures);
+
+	visual_animation_managerst manager;
+	uint32_t now_ms=1000;
+	uint64_t sync_us=0,lookup_us=0,facing_us=0;
+	uint64_t active=0;
+	const int frames=300;
+	for(int frame=0;frame<frames;++frame)
+		{
+		// A step every sixth frame: half the creatures move one tile.
+		if(frame%6==0)
+			{
+			buffers.advance();
+			for(creaturest &creature:creatures)
+				{
+				if(rng()%2)continue;
+				const int32_t nx=creature.x+int32_t(rng()%3)-1;
+				const int32_t ny=creature.y+int32_t(rng()%3)-1;
+				if(nx>0&&nx<dim_x-1&&ny>0&&ny<dim_y-1)
+					{
+					creature.x=nx;
+					creature.y=ny;
+					}
+				}
+			draw(buffers,creatures);
+			}
+		manager.begin_frame(now_ms);
+		const uint64_t t0=now_us();
+		manager.synchronize_viewport(buffers.input());
+		manager.end_frame();
+		const uint64_t t1=now_us();
+		// What collect_proxies does: one lookup per drawn tile in every layer.
+		for(size_t layer=0;layer<layer_count;++layer)
+			{
+			const std::vector<int32_t> &current=buffers.current[layer];
+			for(int32_t x=0;x<dim_x;++x)
+				for(int32_t y=0;y<dim_y;++y)
+					{
+					if(current[size_t(x)*dim_y+size_t(y)]==0)continue;
+					const visual_movement_renderst movement=manager.get_movement(
+						&buffers,static_cast<viewport_visual_layer>(layer),x,y);
+					if(movement.active)++active;
+					}
+			}
+		const uint64_t t2=now_us();
+		// What the resting mirrored pass does: one facing lookup per tile.
+		uint64_t mirrored=0;
+		for(int32_t x=0;x<dim_x;++x)
+			for(int32_t y=0;y<dim_y;++y)
+				if(manager.get_facing(&buffers,x,y)!=native_sprite_facing)++mirrored;
+		const uint64_t t3=now_us();
+		sync_us+=t1-t0;
+		lookup_us+=t2-t1;
+		facing_us+=t3-t2;
+		if(mirrored>tiles)std::printf("unreachable\n");
+		now_ms+=16;
+		}
+	std::printf("%4d creatures: sync %6.1f us  movement lookups %6.1f us  facing lookups %6.1f us  per frame (%.1f active lookups/frame)\n",
+		creature_count,double(sync_us)/frames,double(lookup_us)/frames,double(facing_us)/frames,double(active)/frames);
+}
+
+} // namespace
+
+int main()
+{
+	std::printf("viewport %dx%d, 300 frames of 16 ms, a step every 6 frames\n",dim_x,dim_y);
+	for(int32_t creatures:{10,50,200})run(creatures);
+	return 0;
+}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <set>
@@ -53,6 +54,58 @@ REQUIRE_GLOBAL(window_z);
 namespace {
 
 constexpr const char *plugin_version="0.5.0";
+
+// Frame timing for `smooth-movement stats`. Counting is always on (a few increments per frame);
+// the clock is read only while enabled. Sync covers movement detection across every viewport,
+// render covers everything after it: proxy collection, tile blanking, engine repaints, sprites.
+struct frame_statsst
+{
+	bool enabled=false;
+	uint64_t frames=0;
+	uint64_t painted=0;
+	uint64_t repaints=0;
+	uint64_t sync_us=0;
+	uint64_t sync_max_us=0;
+	uint64_t render_us=0;
+	uint64_t render_max_us=0;
+
+	static uint64_t now_us()
+		{
+		return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count());
+		}
+
+	void clear()
+		{
+		frames=painted=repaints=0;
+		sync_us=sync_max_us=render_us=render_max_us=0;
+		}
+
+	void add_sync(uint64_t us)
+		{
+		sync_us+=us;
+		sync_max_us=std::max(sync_max_us,us);
+		}
+
+	void add_render(uint64_t us)
+		{
+		render_us+=us;
+		render_max_us=std::max(render_max_us,us);
+		}
+};
+
+frame_statsst frame_stats;
+
+// Runs a callback when the scope ends, whichever return path is taken.
+template<typename Callback>
+struct scope_guardst
+{
+	Callback callback;
+	explicit scope_guardst(Callback c):callback(std::move(c)){}
+	~scope_guardst(){callback();}
+	scope_guardst(const scope_guardst &)=delete;
+	scope_guardst &operator=(const scope_guardst &)=delete;
+};
 
 // Runtime harness for the engine-owned visual state; gameplay data is never read.
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
@@ -649,6 +702,13 @@ void with_upper_suppressed(
 		});
 }
 
+// Every engine repaint the plugin asks for goes through here so `stats` can count them.
+void engine_repaint(df::renderer_2d_base *renderer,df::graphic_viewportst *vp,int32_t x,int32_t y)
+{
+	++frame_stats.repaints;
+	renderer->update_viewport_tile(vp,x,y);
+}
+
 void redraw_viewport_tile(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
@@ -658,7 +718,7 @@ void redraw_viewport_tile(
 {
 	df::graphic_viewportst *vp=viewport.viewport;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto stage=[&]
 		{
 		with_suppressed_visual_layers(
@@ -701,7 +761,7 @@ void draw_interface_only(
 {
 	if(!interface_pass_readable(vp))return;
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto without_visuals=[&]
 		{
 		with_suppressed_visual_layers(
@@ -764,7 +824,7 @@ void redraw_above(
 	const std::unordered_map<int32_t,uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
-	const auto redraw=[&]{renderer->update_viewport_tile(vp,x,y);};
+	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
 	const auto suppress_visuals=[&]
 		{
 		const auto stage=[&]
@@ -890,7 +950,7 @@ SDL_Texture *cached_viewport_texture(
 	// Hauled items are not normally drawn, so stage one tile to populate the renderer cache.
 	scoped_value_restorest<int32_t> staged(vp->screentexpos_background_two[index]);
 	vp->screentexpos_background_two[index]=texpos;
-	renderer->update_viewport_tile(vp,index/vp->dim_y,index%vp->dim_y);
+	engine_repaint(renderer,vp,index/vp->dim_y,index%vp->dim_y);
 	return cached_texture(renderer,texpos);
 }
 
@@ -1324,6 +1384,17 @@ bool has_mirrored_viewport_facing(
 
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
+	++frame_stats.frames;
+	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	uint64_t sync_end_us=frame_start_us;
+	// Runs on every exit, including the early return for frames with nothing to draw.
+	const scope_guardst timing([&]
+		{
+		if(!frame_stats.enabled)return;
+		const uint64_t end_us=frame_statsst::now_us();
+		frame_stats.add_sync(sync_end_us-frame_start_us);
+		frame_stats.add_render(end_us-sync_end_us);
+		});
 	df::graphic_viewportst *vp=gps?gps->main_viewport:nullptr;
 	const std::vector<df::graphic_viewportst *> viewports=active_viewports();
 
@@ -1342,6 +1413,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
+	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;
@@ -1374,6 +1446,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
 		carried_items.empty()&&previous_coverage.empty())
 		return;
+	++frame_stats.painted;
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
@@ -1524,6 +1597,33 @@ void reset_state()
 	native_follow_id=-1;
 	flip_enabled=false;
 	hauled_enabled=false;
+	frame_stats.clear();
+}
+
+void print_frame_stats(color_ostream &out)
+{
+	const frame_statsst &f=frame_stats;
+	out.print("frame stats: {}\n",f.enabled?"on":"off");
+	if(f.frames==0)
+		{
+		out.print("no frames recorded\n");
+		return;
+		}
+	const auto mean=[](uint64_t total,uint64_t count)
+		{
+		return count==0?0.0:double(total)/double(count);
+		};
+	out.print("frames: {} ({} painted, {:.0f}%)\n",
+		f.frames,f.painted,100.0*mean(f.painted,f.frames));
+	out.print("engine tile repaints: {} ({:.1f} per frame, {:.1f} per painted frame)\n",
+		f.repaints,mean(f.repaints,f.frames),mean(f.repaints,f.painted));
+	if(!f.enabled)return;
+	out.print("sync: mean {:.0f} us, max {} us (every frame)\n",
+		mean(f.sync_us,f.frames),f.sync_max_us);
+	out.print("render: mean {:.0f} us, max {} us (every frame; {:.0f} us per painted frame)\n",
+		mean(f.render_us,f.frames),f.render_max_us,mean(f.render_us,f.painted));
+	out.print("total: mean {:.0f} us per frame\n",
+		mean(f.sync_us+f.render_us,f.frames));
 }
 
 command_result status_command(
@@ -1544,7 +1644,32 @@ command_result status_command(
 			animation_manager.is_linear()?"on":"off");
 		out.print("hauled item icons: {}\n",
 			hauled_enabled?"on":"off");
+		out.print("frame stats: {}\n",
+			frame_stats.enabled?"on":"off");
 		return CR_OK;
+		}
+	if(parameters[0]=="stats")
+		{
+		if(parameters.size()==1)
+			{
+			print_frame_stats(out);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&
+			(parameters[1]=="on"||parameters[1]=="off"))
+			{
+			frame_stats.enabled=parameters[1]=="on";
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats {}\n",parameters[1]);
+			return CR_OK;
+			}
+		if(parameters.size()==2&&parameters[1]=="reset")
+			{
+			frame_stats.clear();
+			out.print("smooth-movement: frame stats reset\n");
+			return CR_OK;
+			}
+		return CR_WRONG_USAGE;
 		}
 	if(parameters[0]=="all")
 		{
@@ -1682,7 +1807,8 @@ plugin_init(color_ostream &,std::vector<PluginCommand> &commands)
 		"Smooth movement status; free camera: camera on|off|reset|<fx> <fy>; "
 		"all non-camera flags: all on|off; "
 		"sprite flipping: flip on|off; linear movement: linear on|off; "
-		"hauled item icons: hauled on|off.",
+		"hauled item icons: hauled on|off; "
+		"frame timing: stats [on|off|reset].",
 		status_command);
 	return CR_OK;
 }

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1385,12 +1385,15 @@ bool has_mirrored_viewport_facing(
 void render_interpolated_world(df::renderer_2d_base *renderer)
 {
 	++frame_stats.frames;
-	const uint64_t frame_start_us=frame_stats.enabled?frame_statsst::now_us():0;
+	// Read once: the console can flip the flag mid-frame, and a frame timed from its start
+	// only is a frame timed from a zero.
+	const bool timing_enabled=frame_stats.enabled;
+	const uint64_t frame_start_us=timing_enabled?frame_statsst::now_us():0;
 	uint64_t sync_end_us=frame_start_us;
 	// Runs on every exit, including the early return for frames with nothing to draw.
 	const scope_guardst timing([&]
 		{
-		if(!frame_stats.enabled)return;
+		if(!timing_enabled)return;
 		const uint64_t end_us=frame_statsst::now_us();
 		frame_stats.add_sync(sync_end_us-frame_start_us);
 		frame_stats.add_render(end_us-sync_end_us);
@@ -1413,7 +1416,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	for(df::graphic_viewportst *viewport:viewports)
 		animation_manager.synchronize_viewport(animation_input(viewport));
 	animation_manager.end_frame();
-	if(frame_stats.enabled)sync_end_us=frame_statsst::now_us();
+	if(timing_enabled)sync_end_us=frame_statsst::now_us();
 
 	if(!viewport_readable(vp)||renderer->sdl_renderer==nullptr)
 		return;

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -111,12 +111,95 @@ struct scope_guardst
 decltype(&SDL_RenderCopyF) render_copy_f=nullptr;
 decltype(&SDL_RenderCopyExF) render_copy_ex_f=nullptr;
 decltype(&SDL_RenderFillRect) render_fill_rect=nullptr;
+decltype(&SDL_RenderFillRects) render_fill_rects=nullptr;
 decltype(&SDL_RenderSetClipRect) render_set_clip_rect=nullptr;
 decltype(&SDL_GetRenderDrawColor) get_render_draw_color=nullptr;
 decltype(&SDL_SetRenderDrawColor) set_render_draw_color=nullptr;
 
 visual_animation_managerst animation_manager;
-std::set<std::pair<int32_t,int32_t>> previous_coverage;
+// The set of tiles a frame touches. A flag per tile answers membership in one load, and the
+// tiles are listed as they arrive so a pass can walk them without scanning the grid. Walks go
+// in x-then-y order, the order the engine sweeps a viewport in, so the flags are sorted first.
+class tile_coveragest
+{
+	int32_t dim_x=0;
+	int32_t dim_y=0;
+	std::vector<uint8_t> flags;
+	std::vector<std::pair<int32_t,int32_t>> marks;
+	bool sorted=true;
+
+	public:
+		bool empty() const
+		{
+			return marks.empty();
+		}
+
+		size_t size() const
+		{
+			return marks.size();
+		}
+
+		void clear()
+		{
+			std::fill(flags.begin(),flags.end(),0);
+			marks.clear();
+			sorted=true;
+		}
+
+		bool count(std::pair<int32_t,int32_t> tile) const
+		{
+			const auto [x,y]=tile;
+			return x>=0&&x<dim_x&&y>=0&&y<dim_y&&flags[size_t(x)*size_t(dim_y)+size_t(y)]!=0;
+		}
+
+		void insert(std::pair<int32_t,int32_t> tile)
+		{
+			const auto [x,y]=tile;
+			if(x<0||y<0)return;
+			if(x>=dim_x||y>=dim_y)grow(x+1,y+1);
+			uint8_t &flag=flags[size_t(x)*size_t(dim_y)+size_t(y)];
+			if(flag)return;
+			flag=1;
+			if(sorted&&!marks.empty()&&marks.back()>tile)sorted=false;
+			marks.push_back(tile);
+		}
+
+		template<typename Iterator>
+		void insert(Iterator first,Iterator last)
+		{
+			for(;first!=last;++first)insert(*first);
+		}
+
+		// The tiles in x-then-y order.
+		const std::vector<std::pair<int32_t,int32_t>> &tiles()
+		{
+			if(!sorted)
+				{
+				std::sort(marks.begin(),marks.end());
+				sorted=true;
+				}
+			return marks;
+		}
+
+	private:
+		void grow(int32_t new_dim_x,int32_t new_dim_y)
+		{
+			new_dim_x=std::max(new_dim_x,dim_x);
+			new_dim_y=std::max(new_dim_y,dim_y);
+			std::vector<uint8_t> grown(size_t(new_dim_x)*size_t(new_dim_y),0);
+			for(const auto &[x,y]:marks)
+				grown[size_t(x)*size_t(new_dim_y)+size_t(y)]=1;
+			flags.swap(grown);
+			dim_x=new_dim_x;
+			dim_y=new_dim_y;
+		}
+};
+
+// The frame's working sets, kept across frames so their grids are allocated once.
+tile_coveragest previous_coverage;
+tile_coveragest coverage_scratch;
+tile_coveragest redraw_coverage_scratch;
+std::vector<SDL_Rect> tile_rects_scratch;
 uint64_t visual_context_revision=0;
 const void *previous_viewport=nullptr;
 std::array<int32_t,12> previous_view_signature{};
@@ -592,7 +675,8 @@ struct render_proxyst
 	SDL_Texture *texture;
 	bool mirrored=false;
 	int32_t mirror_shift=0;
-	std::set<std::pair<int32_t,int32_t>> coverage;
+	// The tiles the sprite crosses; a handful, listed once each.
+	std::vector<std::pair<int32_t,int32_t>> coverage;
 };
 
 struct carried_item_proxyst
@@ -603,16 +687,15 @@ struct carried_item_proxyst
 	int32_t target_y;
 	float progress;
 	SDL_Texture *texture;
-	std::set<std::pair<int32_t,int32_t>> coverage;
+	std::vector<std::pair<int32_t,int32_t>> coverage;
 };
-
-using tile_coveragest=std::set<std::pair<int32_t,int32_t>>;
 
 struct render_coveragest
 {
 	tile_coveragest all;
 	std::array<tile_coveragest,static_cast<size_t>(visual_render_groupst::count)> groups;
-	std::unordered_map<int32_t,uint16_t> selected;
+	// The visual layers with a proxy on each tile, indexed like the viewport buffers.
+	std::vector<uint16_t> selected;
 };
 
 struct viewport_renderst
@@ -627,12 +710,9 @@ constexpr uint16_t visual_layer_bit(viewport_visual_layer layer)
 	return uint16_t(1U<<static_cast<uint8_t>(layer));
 }
 
-uint16_t selected_mask(
-	const std::unordered_map<int32_t,uint16_t> &selected,
-	int32_t index)
+uint16_t selected_mask(const std::vector<uint16_t> &selected,int32_t index)
 {
-	const auto found=selected.find(index);
-	return found==selected.end()?0:found->second;
+	return index>=0&&size_t(index)<selected.size()?selected[size_t(index)]:0;
 }
 
 template<size_t Layer=0,typename Callback>
@@ -821,7 +901,7 @@ void redraw_above(
 	int32_t x,
 	int32_t y,
 	visual_render_groupst group,
-	const std::unordered_map<int32_t,uint16_t> &selected)
+	const std::vector<uint16_t> &selected)
 {
 	const int32_t index=x*vp->dim_y+y;
 	const auto redraw=[&]{engine_repaint(renderer,vp,x,y);};
@@ -1008,7 +1088,7 @@ std::vector<carried_item_proxyst> collect_carried_item_proxies(
 			for(int32_t coverage_y=int32_t(std::floor(std::min(source_y,float(y))));
 				coverage_y<=int32_t(std::ceil(std::max(source_y,float(y))));++coverage_y)
 				if(inside_clip(vp,coverage_x,coverage_y))
-					proxy.coverage.emplace(coverage_x,coverage_y);
+					proxy.coverage.push_back({coverage_x,coverage_y});
 		proxies.push_back(std::move(proxy));
 		}
 	return proxies;
@@ -1160,31 +1240,32 @@ std::vector<render_proxyst> collect_proxies(
 							blocked=true;
 							break;
 							}
-						proxy.coverage.emplace(coverage_x,coverage_y);
+						proxy.coverage.push_back({coverage_x,coverage_y});
 						}
 					if(blocked)break;
 					}
 				if(blocked)continue;
 				if(proxy.mirror_shift!=0)
 					{
-					std::set<std::pair<int32_t,int32_t>> mirrored_coverage;
-					for(const auto &tile:proxy.coverage)
-						mirrored_coverage.emplace(
-							tile.first+proxy.mirror_shift,tile.second);
-					for(const auto &tile:mirrored_coverage)
+					// The shifted copies are appended behind the originals; a shifted tile
+					// that lands on an original is listed twice, which the coverage absorbs.
+					const size_t unshifted=proxy.coverage.size();
+					for(size_t tile=0;tile<unshifted;++tile)
 						{
-						if(!inside_clip(vp,tile.first,tile.second))
+						const int32_t tile_x=proxy.coverage[tile].first+proxy.mirror_shift;
+						const int32_t tile_y=proxy.coverage[tile].second;
+						if(!inside_clip(vp,tile_x,tile_y))
 							{
 							blocked=true;
 							break;
 							}
 						if(visual_render_group(proxy.layer)==visual_render_groupst::main&&
-							has_fire(vp,tile.first,tile.second))
+							has_fire(vp,tile_x,tile_y))
 							{
 							blocked=true;
 							break;
 							}
-						proxy.coverage.insert(tile);
+						proxy.coverage.push_back({tile_x,tile_y});
 						}
 					if(blocked)continue;
 					}
@@ -1203,12 +1284,11 @@ std::vector<render_proxyst> collect_proxies(
 	// A fragment's tile is its anchor minus the layer's centre offset, inverting the moving path.
 	if(flip_enabled)
 		{
-		// (layer, tile) pairs already given a proxy, so a resting sprite is not drawn twice.
-		std::set<std::pair<uint8_t,int32_t>> drawn;
+		// The layers already given a proxy on each tile, so a resting sprite is not drawn twice.
+		std::vector<uint16_t> drawn(size_t(vp->dim_x)*size_t(vp->dim_y),0);
 		for(const render_proxyst &existing:proxies)
-			drawn.emplace(
-				static_cast<uint8_t>(existing.layer),
-				existing.target_x*vp->dim_y+existing.target_y);
+			drawn[size_t(existing.target_x*vp->dim_y+existing.target_y)]|=
+				visual_layer_bit(existing.layer);
 		// Mirrored tiles come in index order, which is the x outer, y inner sweep order.
 		for(const int32_t anchor_index:animation_manager.mirrored_tiles(vp))
 			{
@@ -1230,8 +1310,7 @@ std::vector<render_proxyst> collect_proxies(
 					const size_t layer=static_cast<size_t>(visual_layer);
 					const int32_t texpos=layers[layer][x*vp->dim_y+y];
 					if(texpos==0)continue;
-					if(drawn.count({static_cast<uint8_t>(visual_layer),x*vp->dim_y+y}))
-						continue;
+					if(drawn[size_t(x*vp->dim_y+y)]&visual_layer_bit(visual_layer))continue;
 
 					// source == target at progress 1.0 draws in place, moved only by mirror_shift.
 					render_proxyst proxy=
@@ -1263,13 +1342,13 @@ std::vector<render_proxyst> collect_proxies(
 							blocked=true;
 							break;
 							}
-						proxy.coverage.emplace(coverage_x,y);
+						proxy.coverage.push_back({coverage_x,y});
 						}
 					if(blocked)continue;
 
 					proxy.texture=cached_texture(renderer,texpos);
 					if(proxy.texture==nullptr)continue;
-					drawn.emplace(static_cast<uint8_t>(visual_layer),x*vp->dim_y+y);
+					drawn[size_t(x*vp->dim_y+y)]|=visual_layer_bit(visual_layer);
 					proxies.push_back(std::move(proxy));
 					}
 				}
@@ -1280,13 +1359,15 @@ std::vector<render_proxyst> collect_proxies(
 
 render_coveragest collect_coverage(
 	const std::vector<render_proxyst> &proxies,
+	int32_t dim_x,
 	int32_t dim_y)
 {
 	render_coveragest coverage;
+	if(!proxies.empty())coverage.selected.assign(size_t(dim_x)*size_t(dim_y),0);
 	for(const render_proxyst &proxy:proxies)
 		{
 		coverage.all.insert(proxy.coverage.begin(),proxy.coverage.end());
-		coverage.selected[proxy.target_x*dim_y+proxy.target_y]|=
+		coverage.selected[size_t(proxy.target_x*dim_y+proxy.target_y)]|=
 			visual_layer_bit(proxy.layer);
 		auto &group=coverage.groups[static_cast<size_t>(visual_render_group(proxy.layer))];
 		group.insert(proxy.coverage.begin(),proxy.coverage.end());
@@ -1317,27 +1398,17 @@ std::vector<viewport_renderst> collect_viewport_renders(
 	for(df::graphic_viewportst *vp:viewports)
 		{
 		viewport_renderst render={vp,collect_proxies(renderer,vp),{}};
-		render.coverage=collect_coverage(render.proxies,vp->dim_y);
+		render.coverage=collect_coverage(render.proxies,vp->dim_x,vp->dim_y);
 		renders.push_back(std::move(render));
 		}
 	return renders;
-}
-
-tile_coveragest collect_viewport_coverage(
-	const std::vector<viewport_renderst> &viewports)
-{
-	tile_coveragest coverage;
-	for(const viewport_renderst &viewport:viewports)
-		coverage.insert(
-			viewport.coverage.all.begin(),viewport.coverage.all.end());
-	return coverage;
 }
 
 void draw_interpolation_stages(
 	df::renderer_2d_base *renderer,
 	df::graphic_viewportst *vp,
 	const std::vector<render_proxyst> &proxies,
-	const render_coveragest &coverage)
+	render_coveragest &coverage)
 {
 	for(size_t index=0;index<coverage.groups.size();++index)
 		{
@@ -1345,7 +1416,7 @@ void draw_interpolation_stages(
 		for(const render_proxyst &proxy:proxies)
 			if(visual_render_group(proxy.layer)==group)draw_proxy(renderer,proxy);
 		if(group==visual_render_groupst::designation)continue;
-		for(const auto &[x,y]:coverage.groups[index])
+		for(const auto &[x,y]:coverage.groups[index].tiles())
 			redraw_above(renderer,vp,x,y,group,coverage.selected);
 		}
 }
@@ -1353,10 +1424,10 @@ void draw_interpolation_stages(
 void redraw_viewport_tiles(
 	df::renderer_2d_base *renderer,
 	const viewport_renderst &viewport,
-	const tile_coveragest &coverage)
+	tile_coveragest &coverage)
 {
 	df::graphic_viewportst *vp=viewport.viewport;
-	for(const auto &[x,y]:coverage)
+	for(const auto &[x,y]:coverage.tiles())
 		{
 		if(!inside_clip(vp,x,y))continue;
 		redraw_viewport_tile(renderer,viewport,x,y,true);
@@ -1365,8 +1436,8 @@ void redraw_viewport_tiles(
 
 void draw_viewport_interpolation_stages(
 	df::renderer_2d_base *renderer,
-	const std::vector<viewport_renderst> &viewports,
-	const tile_coveragest &coverage,
+	std::vector<viewport_renderst> &viewports,
+	tile_coveragest &coverage,
 	const std::vector<carried_item_proxyst> &carried_items)
 {
 	for(size_t index=0;index<viewports.size();++index)
@@ -1374,7 +1445,7 @@ void draw_viewport_interpolation_stages(
 		// A lower z-level's proxy must be covered by the next viewport's fog and terrain.
 		// Reapply that viewport before its own proxies, matching DF's lower-to-main draw order.
 		if(index>0)redraw_viewport_tiles(renderer,viewports[index],coverage);
-		const viewport_renderst &viewport=viewports[index];
+		viewport_renderst &viewport=viewports[index];
 		draw_interpolation_stages(
 			renderer,viewport.viewport,viewport.proxies,viewport.coverage);
 		if(index+1==viewports.size())
@@ -1382,7 +1453,7 @@ void draw_viewport_interpolation_stages(
 				draw_carried_item_proxy(renderer,proxy);
 		// A viewport shades everything drawn beneath it, so this covers every staged tile.
 		// Restricting it to the tiles this viewport has sprites on would not deepen with distance.
-		for(const auto &[x,y]:coverage)
+		for(const auto &[x,y]:coverage.tiles())
 			{
 			if(inside_clip(viewport.viewport,x,y))
 				draw_interface_only(renderer,viewport.viewport,x,y);
@@ -1469,7 +1540,13 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 
 	std::vector<viewport_renderst> viewport_renders=
 		collect_viewport_renders(renderer,viewports);
-	tile_coveragest coverage=collect_viewport_coverage(viewport_renders);
+	tile_coveragest &coverage=coverage_scratch;
+	coverage.clear();
+	for(viewport_renderst &viewport:viewport_renders)
+		{
+		const auto &tiles=viewport.coverage.all.tiles();
+		coverage.insert(tiles.begin(),tiles.end());
+		}
 	for(const carried_item_proxyst &proxy:carried_items)
 		coverage.insert(proxy.coverage.begin(),proxy.coverage.end());
 
@@ -1520,26 +1597,34 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		return;
 		}
 
-	tile_coveragest redraw_coverage=coverage;
-	redraw_coverage.insert(previous_coverage.begin(),previous_coverage.end());
-	Uint8 old_r=0,old_g=0,old_b=0,old_a=255;
-	get_render_draw_color(sdl_renderer,&old_r,&old_g,&old_b,&old_a);
-	set_render_draw_color(sdl_renderer,0,0,0,255);
-	for(const auto &[x,y]:redraw_coverage)
+	tile_coveragest &redraw_coverage=redraw_coverage_scratch;
+	redraw_coverage.clear();
+	redraw_coverage.insert(coverage.tiles().begin(),coverage.tiles().end());
+	redraw_coverage.insert(previous_coverage.tiles().begin(),previous_coverage.tiles().end());
+	// Every tile blanks to the same colour, so they go to the renderer as one call.
+	std::vector<SDL_Rect> &tile_rects=tile_rects_scratch;
+	tile_rects.clear();
+	for(const auto &[x,y]:redraw_coverage.tiles())
 		{
 		if(!inside_clip(vp,x,y))continue;
-		const SDL_Rect tile_rect=
+		tile_rects.push_back(
 			{
 			tile_pixel(x,renderer->origin_x,zoom),
 			tile_pixel(y,renderer->origin_y,zoom),
 			tile_size,
 			tile_size
-			};
-		render_fill_rect(sdl_renderer,&tile_rect);
+			});
 		}
-	set_render_draw_color(sdl_renderer,old_r,old_g,old_b,old_a);
+	if(!tile_rects.empty())
+		{
+		Uint8 old_r=0,old_g=0,old_b=0,old_a=255;
+		get_render_draw_color(sdl_renderer,&old_r,&old_g,&old_b,&old_a);
+		set_render_draw_color(sdl_renderer,0,0,0,255);
+		render_fill_rects(sdl_renderer,tile_rects.data(),int(tile_rects.size()));
+		set_render_draw_color(sdl_renderer,old_r,old_g,old_b,old_a);
+		}
 
-	for(const auto &[x,y]:redraw_coverage)
+	for(const auto &[x,y]:redraw_coverage.tiles())
 		{
 		if(inside_clip(vp,x,y))
 			redraw_world_tile(renderer,viewport_renders,coverage,x,y);
@@ -1547,7 +1632,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 	draw_viewport_interpolation_stages(
 		renderer,viewport_renders,coverage,carried_items);
 
-	previous_coverage=std::move(coverage);
+	std::swap(previous_coverage,coverage);
 }
 
 struct renderer_hook : df::renderer_2d_base
@@ -1570,6 +1655,7 @@ void clear_sdl_bindings()
 	render_copy_f=nullptr;
 	render_copy_ex_f=nullptr;
 	render_fill_rect=nullptr;
+	render_fill_rects=nullptr;
 	render_set_clip_rect=nullptr;
 	get_render_draw_color=nullptr;
 	set_render_draw_color=nullptr;
@@ -1589,6 +1675,7 @@ bool load_sdl(color_ostream &out)
 	bind(SDL_RenderCopyF,render_copy_f);
 	bind(SDL_RenderCopyExF,render_copy_ex_f);
 	bind(SDL_RenderFillRect,render_fill_rect);
+	bind(SDL_RenderFillRects,render_fill_rects);
 	bind(SDL_RenderSetClipRect,render_set_clip_rect);
 	bind(SDL_GetRenderDrawColor,get_render_draw_color);
 	bind(SDL_SetRenderDrawColor,set_render_draw_color);

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -1021,14 +1021,38 @@ std::vector<render_proxyst> collect_proxies(
 	std::vector<render_proxyst> proxies;
 	auto layers=visual_layers(vp);
 	auto previous_layers=visual_layers(vp,true);
+	// Only tiles the manager can report a movement for are visited, in the row order
+	// (y outer, x inner) the full sweep used, so the proxies come out in the same order.
+	std::vector<int32_t> candidate_tiles;
+	animation_manager.active_movement_tiles(vp,candidate_tiles);
+	for(int32_t &tile:candidate_tiles)tile=(tile%vp->dim_y)*vp->dim_x+tile/vp->dim_y;
+	std::sort(candidate_tiles.begin(),candidate_tiles.end());
+	candidate_tiles.erase(
+		std::unique(candidate_tiles.begin(),candidate_tiles.end()),candidate_tiles.end());
+	// The center layer is drawn first, so every anchor a fragment can attach to is already a
+	// proxy by the time the fragment is visited; one lookup per tile replaces a scan.
+	std::vector<int32_t> center_proxy_at(size_t(vp->dim_x)*size_t(vp->dim_y),-1);
+	const auto anchor_matches=[&](
+		int32_t anchor_x,int32_t anchor_y,int32_t x,int32_t y,
+		const visual_movement_renderst &movement)
+		{
+		if(anchor_x<0||anchor_x>=vp->dim_x||anchor_y<0||anchor_y>=vp->dim_y)return false;
+		const int32_t proxy_index=center_proxy_at[size_t(anchor_x*vp->dim_y+anchor_y)];
+		if(proxy_index<0)return false;
+		const render_proxyst &anchor=proxies[size_t(proxy_index)];
+		return anchor.source_x-anchor.target_x==movement.source_x-x&&
+			anchor.source_y-anchor.target_y==movement.source_y-y&&
+			anchor.progress==movement.progress;
+		};
 	for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
 		{
 		const viewport_visual_layer visual_layer=visual_layer_at_draw_order(draw_order);
 		const size_t layer=static_cast<size_t>(visual_layer);
-		for(int32_t y=0;y<vp->dim_y;++y)
+		for(const int32_t row_tile:candidate_tiles)
 			{
-			for(int32_t x=0;x<vp->dim_x;++x)
 				{
+				const int32_t x=row_tile%vp->dim_x;
+				const int32_t y=row_tile/vp->dim_x;
 				const int32_t index=x*vp->dim_y+y;
 				const int32_t texpos=layers[layer][index];
 				if(texpos==0)continue;
@@ -1045,15 +1069,9 @@ std::vector<render_proxyst> collect_proxies(
 				if(!visual_layer_moves_independently(visual_layer))
 					{
 					bool anchored=false;
-					for(const render_proxyst &anchor:proxies)
-						{
-						if(anchor.layer==viewport_visual_layer::center&&
-							std::abs(anchor.target_x-x)<=1&&
-							std::abs(anchor.target_y-y)<=1&&
-							anchor.source_x-anchor.target_x==movement.source_x-x&&
-							anchor.source_y-anchor.target_y==movement.source_y-y&&
-							anchor.progress==movement.progress)anchored=true;
-						}
+					for(int32_t dx=-1;dx<=1&&!anchored;++dx)
+						for(int32_t dy=-1;dy<=1&&!anchored;++dy)
+							anchored=anchor_matches(x+dx,y+dy,x,y,movement);
 					if(!anchored)continue;
 					}
 					if((visual_layer==viewport_visual_layer::item||
@@ -1082,15 +1100,8 @@ std::vector<render_proxyst> collect_proxies(
 					if(!fragment_moved)
 						{
 					const auto &descriptor=visual_layer_descriptor(visual_layer);
-					bool owns_fragment=false;
-					for(const render_proxyst &anchor:proxies)
-						if(anchor.layer==viewport_visual_layer::center&&
-							anchor.target_x==x+descriptor.center_x&&
-							anchor.target_y==y+descriptor.center_y&&
-							anchor.source_x-anchor.target_x==movement.source_x-x&&
-							anchor.source_y-anchor.target_y==movement.source_y-y&&
-							anchor.progress==movement.progress)owns_fragment=true;
-					if(!owns_fragment)continue;
+					if(!anchor_matches(
+						x+descriptor.center_x,y+descriptor.center_y,x,y,movement))continue;
 						}
 					}
 
@@ -1180,6 +1191,8 @@ std::vector<render_proxyst> collect_proxies(
 
 				proxy.texture=cached_texture(renderer,texpos);
 				if(proxy.texture==nullptr)continue;
+				if(visual_layer==viewport_visual_layer::center)
+					center_proxy_at[size_t(index)]=int32_t(proxies.size());
 				proxies.push_back(std::move(proxy));
 				}
 			}
@@ -1190,12 +1203,18 @@ std::vector<render_proxyst> collect_proxies(
 	// A fragment's tile is its anchor minus the layer's centre offset, inverting the moving path.
 	if(flip_enabled)
 		{
-		for(int32_t anchor_x=0;anchor_x<vp->dim_x;++anchor_x)
+		// (layer, tile) pairs already given a proxy, so a resting sprite is not drawn twice.
+		std::set<std::pair<uint8_t,int32_t>> drawn;
+		for(const render_proxyst &existing:proxies)
+			drawn.emplace(
+				static_cast<uint8_t>(existing.layer),
+				existing.target_x*vp->dim_y+existing.target_y);
+		// Mirrored tiles come in index order, which is the x outer, y inner sweep order.
+		for(const int32_t anchor_index:animation_manager.mirrored_tiles(vp))
 			{
-			for(int32_t anchor_y=0;anchor_y<vp->dim_y;++anchor_y)
 				{
-				if(animation_manager.get_facing(vp,anchor_x,anchor_y)==
-					native_sprite_facing)continue;
+				const int32_t anchor_x=anchor_index/vp->dim_y;
+				const int32_t anchor_y=anchor_index%vp->dim_y;
 				for(uint8_t draw_order=0;draw_order<visual_layer_count;++draw_order)
 					{
 					const viewport_visual_layer visual_layer=
@@ -1211,12 +1230,8 @@ std::vector<render_proxyst> collect_proxies(
 					const size_t layer=static_cast<size_t>(visual_layer);
 					const int32_t texpos=layers[layer][x*vp->dim_y+y];
 					if(texpos==0)continue;
-					bool already_drawn=false;
-					for(const render_proxyst &existing:proxies)
-						if(existing.layer==visual_layer&&
-							existing.target_x==x&&existing.target_y==y)
-							already_drawn=true;
-					if(already_drawn)continue;
+					if(drawn.count({static_cast<uint8_t>(visual_layer),x*vp->dim_y+y}))
+						continue;
 
 					// source == target at progress 1.0 draws in place, moved only by mirror_shift.
 					render_proxyst proxy=
@@ -1254,6 +1269,7 @@ std::vector<render_proxyst> collect_proxies(
 
 					proxy.texture=cached_texture(renderer,texpos);
 					if(proxy.texture==nullptr)continue;
+					drawn.emplace(static_cast<uint8_t>(visual_layer),x*vp->dim_y+y);
 					proxies.push_back(std::move(proxy));
 					}
 				}

--- a/smooth-movement.cpp
+++ b/smooth-movement.cpp
@@ -196,20 +196,12 @@ class tile_coveragest
 };
 
 // The frame's working sets, kept across frames so their grids are allocated once.
-tile_coveragest previous_coverage;
 tile_coveragest coverage_scratch;
-tile_coveragest redraw_coverage_scratch;
 std::vector<SDL_Rect> tile_rects_scratch;
 uint64_t visual_context_revision=0;
 const void *previous_viewport=nullptr;
 std::array<int32_t,12> previous_view_signature{};
 bool has_view_signature=false;
-// Map scroll (window_x/window_y) is tracked separately from the reset signature: a pure pan is
-// followed (movements are translated) instead of triggering a full reset, so it must NOT bump the
-// context revision. It only invalidates the viewport-space blackout coverage from the prior frame.
-int32_t previous_pan_x=0;
-int32_t previous_pan_y=0;
-bool has_pan_context=false;
 bool flip_enabled=false;
 bool hauled_enabled=false;
 
@@ -491,22 +483,11 @@ void update_visual_context(
 	if(changed)
 		{
 		++visual_context_revision;
-		previous_coverage.clear();
 		cancel_camera_transients();
 		}
 	previous_viewport=vp;
 	previous_view_signature=signature;
 	has_view_signature=true;
-
-	// On a pure pan the reset signature is unchanged, but last frame's blackout coverage is in the
-	// old viewport frame, so discard it (the engine repaints the whole scrolled viewport anyway).
-	const int32_t pan_x=window_x?*window_x:0;
-	const int32_t pan_y=window_y?*window_y:0;
-	if(!has_pan_context||previous_pan_x!=pan_x||previous_pan_y!=pan_y)
-		previous_coverage.clear();
-	previous_pan_x=pan_x;
-	previous_pan_y=pan_y;
-	has_pan_context=true;
 }
 
 using viewport_layer_memberst=int32_t *df::graphic_viewportst::*;
@@ -1494,7 +1475,6 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		{
 		native_follow_id=follow_id;
 		++visual_context_revision;
-		previous_coverage.clear();
 		cancel_camera_transients();
 		camera_has_prev=false;
 		}
@@ -1534,7 +1514,7 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		std::vector<carried_item_proxyst>{};
 	if(!glide&&!animation_manager.requires_full_redraw()&&
 		(!flip_enabled||!has_mirrored_viewport_facing(viewports))&&
-		carried_items.empty()&&previous_coverage.empty())
+		carried_items.empty())
 		return;
 	++frame_stats.painted;
 
@@ -1591,20 +1571,15 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		renderer->origin_x=saved_origin_x;
 		renderer->origin_y=saved_origin_y;
 		render_set_clip_rect(sdl_renderer,nullptr);
-
-		// Everything was repainted; per-tile coverage bookkeeping restarts after the glide.
-		previous_coverage.clear();
 		return;
 		}
 
-	tile_coveragest &redraw_coverage=redraw_coverage_scratch;
-	redraw_coverage.clear();
-	redraw_coverage.insert(coverage.tiles().begin(),coverage.tiles().end());
-	redraw_coverage.insert(previous_coverage.tiles().begin(),previous_coverage.tiles().end());
+	// The engine repaints every viewport tile each frame before this hook runs, so a tile a
+	// sprite covered last frame is clean again by now: only this frame's coverage is blanked.
 	// Every tile blanks to the same colour, so they go to the renderer as one call.
 	std::vector<SDL_Rect> &tile_rects=tile_rects_scratch;
 	tile_rects.clear();
-	for(const auto &[x,y]:redraw_coverage.tiles())
+	for(const auto &[x,y]:coverage.tiles())
 		{
 		if(!inside_clip(vp,x,y))continue;
 		tile_rects.push_back(
@@ -1624,15 +1599,13 @@ void render_interpolated_world(df::renderer_2d_base *renderer)
 		set_render_draw_color(sdl_renderer,old_r,old_g,old_b,old_a);
 		}
 
-	for(const auto &[x,y]:redraw_coverage.tiles())
+	for(const auto &[x,y]:coverage.tiles())
 		{
 		if(inside_clip(vp,x,y))
 			redraw_world_tile(renderer,viewport_renders,coverage,x,y);
 		}
 	draw_viewport_interpolation_stages(
 		renderer,viewport_renders,coverage,carried_items);
-
-	std::swap(previous_coverage,coverage);
 }
 
 struct renderer_hook : df::renderer_2d_base
@@ -1686,14 +1659,10 @@ bool load_sdl(color_ostream &out)
 void reset_state()
 {
 	animation_manager=visual_animation_managerst();
-	previous_coverage.clear();
 	visual_context_revision=0;
 	previous_viewport=nullptr;
 	previous_view_signature={};
 	has_view_signature=false;
-	previous_pan_x=0;
-	previous_pan_y=0;
-	has_pan_context=false;
 	cancel_camera_transients();
 	rest_x=0.0;
 	rest_y=0.0;

--- a/test_visual_animation_manager.cpp
+++ b/test_visual_animation_manager.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
 #include <array>
 #ifdef NDEBUG
 #undef NDEBUG
@@ -7,6 +8,7 @@
 #include <cassert>
 #include <cstdint>
 #include <limits>
+#include <vector>
 
 #include "visual_animation.h"
 
@@ -206,6 +208,90 @@ int main()
 	set_layer(input,viewport_visual_layer::center,up,west_after);
 	run_frame(manager,input,1032);
 	assert(manager.get_facing(viewport,1,1)==visual_facingst::west);
+	}
+
+	// The manager lists the tiles a movement can be looked up on: the target plus the 3x3
+	// around a center target, where fragments in other layers borrow its movement.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	std::vector<int32_t> tiles;
+	manager.active_movement_tiles(viewport,tiles);
+	assert(tiles.empty());
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	manager.active_movement_tiles(viewport,tiles);
+	std::sort(tiles.begin(),tiles.end());
+	assert(tiles.size()==9);
+	for(int32_t x=0;x<=2;++x)
+		for(int32_t y=1;y<=3;++y)
+			assert(std::binary_search(tiles.begin(),tiles.end(),x*dim+y));
+	// A right-hand fragment next to the target inherits the movement through the index.
+	const auto fragment=manager.get_movement(viewport,viewport_visual_layer::right,2,2);
+	assert(fragment.active&&fragment.inherited);
+	assert(fragment.source_x==3.0f&&fragment.source_y==2.0f);
+	// Vehicles and the center layer itself never borrow a neighbour's movement.
+	assert(!manager.get_movement(viewport,viewport_visual_layer::vehicle,2,2).active);
+	assert(!manager.get_movement(viewport,viewport_visual_layer::center,2,2).active);
+	// Off-grid lookups fall through to the scan and find nothing.
+	assert(!manager.get_movement(viewport,viewport_visual_layer::right,-1,2).active);
+	assert(!manager.get_movement(viewport,viewport_visual_layer::right,dim,2).active);
+	tiles.clear();
+	manager.active_movement_tiles(nullptr,tiles);
+	assert(tiles.empty());
+	// An expired movement leaves the index as it left the scan.
+	run_frame(manager,input,1016+1000);
+	tiles.clear();
+	manager.active_movement_tiles(viewport,tiles);
+	assert(tiles.empty());
+	assert(!manager.get_movement(viewport,viewport_visual_layer::right,2,2).active);
+	}
+
+	// Two center movements with different deltas next to one tile make it ambiguous; a tile
+	// with only one of them in reach still inherits.
+	{
+	int32_t pair_before[dim*dim]={};
+	int32_t pair_after[dim*dim]={};
+	pair_before[0*dim+0]=77;
+	pair_before[3*dim+3]=78;
+	pair_after[1*dim+1]=77;   // south-east
+	pair_after[2*dim+2]=78;   // north-west
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,pair_before,empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,pair_after,pair_before);
+	run_frame(manager,input,1016);
+	assert(manager.get_movement(viewport,viewport_visual_layer::center,1,1).active);
+	assert(manager.get_movement(viewport,viewport_visual_layer::center,2,2).active);
+	assert(!manager.get_movement(viewport,viewport_visual_layer::right,2,1).active);
+	assert(!manager.get_movement(viewport,viewport_visual_layer::up,1,2).active);
+	const auto only_first=manager.get_movement(viewport,viewport_visual_layer::right,0,1);
+	assert(only_first.active&&only_first.source_x==-1.0f&&only_first.source_y==0.0f);
+	const auto only_second=manager.get_movement(viewport,viewport_visual_layer::left,3,2);
+	assert(only_second.active&&only_second.source_x==4.0f&&only_second.source_y==3.0f);
+	}
+
+	// The mirrored tile list mirrors has_mirrored: filled by an eastward step, emptied when the
+	// tile clears, and in index order.
+	{
+	visual_animation_managerst manager;
+	auto input=make_input(viewport,dim,empty);
+	set_layer(input,viewport_visual_layer::center,before,empty);
+	run_frame(manager,input,1000);
+	set_layer(input,viewport_visual_layer::center,west_after,before);
+	run_frame(manager,input,1016);
+	assert(manager.mirrored_tiles(viewport).empty());
+	set_layer(input,viewport_visual_layer::center,before,west_after);
+	run_frame(manager,input,1032);
+	assert(manager.mirrored_tiles(viewport).size()==1);
+	assert(manager.mirrored_tiles(viewport)[0]==2*dim+2);
+	assert(manager.mirrored_tiles(nullptr).empty());
+	set_layer(input,viewport_visual_layer::center,empty,before);
+	run_frame(manager,input,1048);
+	assert(manager.mirrored_tiles(viewport).empty());
 	}
 
 	// Out-of-range and unknown viewports fall back to the native facing.

--- a/visual_animation.h
+++ b/visual_animation.h
@@ -319,6 +319,16 @@ class visual_animation_managerst
 		bool abandoned_this_frame=false;
 		std::array<int32_t,2> landed_shift{};
 		visual_movement_idst follow_candidate=no_visual_movement;
+		// Active movements by (layer, target tile), so get_movement is a lookup rather than a
+		// scan. Slots hold an index into `movements`, -1 when empty; `indexed_slots` lists the
+		// filled ones so a rebuild clears only those instead of the whole grid.
+		std::vector<int32_t> movement_index;
+		std::vector<int32_t> indexed_slots;
+		// Two active center movements on one target tile: the companion rule needs both, so
+		// get_movement scans `movements` instead of reading the index.
+		bool movement_index_ambiguous=false;
+		// Tiles whose facing is mirrored, in tile-index order. Maintained with has_mirrored.
+		std::vector<int32_t> mirrored_tiles;
 	};
 
 	uint32_t frame_time_ms=0;
@@ -376,6 +386,7 @@ class visual_animation_managerst
 			state.facing.end(),
 			int8_t(native_sprite_facing));
 		state.has_mirrored=false;
+		state.mirrored_tiles.clear();
 		}
 
 	static void reset_tracking(viewport_animationst &state)
@@ -550,6 +561,151 @@ class visual_animation_managerst
 			(linear?movement.duration_ms:movement_duration_ms);
 		}
 
+	static size_t movement_slot(
+		const viewport_animationst &state,
+		viewport_visual_layer layer,
+		int32_t x,
+		int32_t y)
+		{
+		return (static_cast<size_t>(layer)*size_t(state.dim_x)+size_t(x))*
+			size_t(state.dim_y)+size_t(y);
+		}
+
+	static bool inside_viewport(const viewport_animationst &state,int32_t x,int32_t y)
+		{
+		return x>=0&&x<state.dim_x&&y>=0&&y<state.dim_y;
+		}
+
+	// Rebuilt after every synchronize_viewport, so the index always describes the frame's
+	// active set. The first movement in vector order wins a slot, as the scan it replaces.
+	void index_movements(viewport_animationst &state)
+		{
+		const size_t slots=state.dim_x>0&&state.dim_y>0?
+			static_cast<size_t>(viewport_visual_layer::count)*size_t(state.dim_x)*size_t(state.dim_y):0;
+		if(state.movement_index.size()!=slots)
+			{
+			state.movement_index.assign(slots,-1);
+			state.indexed_slots.clear();
+			}
+		for(int32_t slot:state.indexed_slots)state.movement_index[size_t(slot)]=-1;
+		state.indexed_slots.clear();
+		state.movement_index_ambiguous=false;
+		for(size_t i=0;i<state.movements.size();++i)
+			{
+			const movementst &movement=state.movements[i];
+			if(!movement_active(movement)||
+				!inside_viewport(state,movement.target_x,movement.target_y))continue;
+			const size_t slot=movement_slot(
+				state,movement.layer,movement.target_x,movement.target_y);
+			if(state.movement_index[slot]>=0)
+				{
+				if(movement.layer==viewport_visual_layer::center)
+					state.movement_index_ambiguous=true;
+				continue;
+				}
+			state.movement_index[slot]=int32_t(i);
+			state.indexed_slots.push_back(int32_t(slot));
+			}
+		}
+
+	static visual_movement_renderst direct_movement(const movementst &movement,float progress)
+		{
+		return {true,movement.source_x,movement.source_y,progress,false,movement.id};
+		}
+
+	static visual_movement_renderst companion_movement(
+		const movementst &companion,
+		int32_t target_x,
+		int32_t target_y,
+		float progress)
+		{
+		return {
+			true,
+			target_x+companion.source_x-companion.target_x,
+			target_y+companion.source_y-companion.target_y,
+			progress,
+			true,
+			companion.id
+			};
+		}
+
+	static bool same_companion(const movementst &a,const movementst &b)
+		{
+		return a.source_x-a.target_x==b.source_x-b.target_x&&
+			a.source_y-a.target_y==b.source_y-b.target_y&&
+			a.start_time_ms==b.start_time_ms&&
+			a.duration_ms==b.duration_ms;
+		}
+
+	// The original lookup: kept for the ambiguous case and as the reference the index must match.
+	visual_movement_renderst scan_movement(
+		const viewport_animationst &state,
+		viewport_visual_layer layer,
+		int32_t target_x,
+		int32_t target_y) const
+		{
+		const movementst *companion=nullptr;
+		bool ambiguous=false;
+		for(const movementst &movement:state.movements)
+			{
+			if(!movement_active(movement))continue;
+			if(movement.layer==layer&&movement.target_x==target_x&&
+				movement.target_y==target_y)
+				return direct_movement(movement,movement_progress(movement));
+			if(layer==viewport_visual_layer::vehicle||
+				layer==viewport_visual_layer::center||
+				movement.layer!=viewport_visual_layer::center||
+				std::abs(movement.target_x-target_x)>1||
+				std::abs(movement.target_y-target_y)>1)continue;
+			if(companion!=nullptr&&!same_companion(*companion,movement))
+				ambiguous=true;
+			else if(companion==nullptr)
+				companion=&movement;
+			}
+		if(ambiguous)return {};
+		if(companion!=nullptr)
+			return companion_movement(
+				*companion,target_x,target_y,movement_progress(*companion));
+		return {};
+		}
+
+	visual_movement_renderst indexed_movement(
+		const viewport_animationst &state,
+		viewport_visual_layer layer,
+		int32_t target_x,
+		int32_t target_y) const
+		{
+		const int32_t direct=state.movement_index[
+			movement_slot(state,layer,target_x,target_y)];
+		if(direct>=0)
+			{
+			const movementst &movement=state.movements[size_t(direct)];
+			return direct_movement(movement,movement_progress(movement));
+			}
+		if(layer==viewport_visual_layer::vehicle||layer==viewport_visual_layer::center)
+			return {};
+		// Any two companions that disagree make the tile ambiguous, so the order of the
+		// nine slots does not matter.
+		const movementst *companion=nullptr;
+		for(int32_t dx=-1;dx<=1;++dx)
+			for(int32_t dy=-1;dy<=1;++dy)
+				{
+				const int32_t x=target_x+dx;
+				const int32_t y=target_y+dy;
+				if(!inside_viewport(state,x,y))continue;
+				const int32_t slot=state.movement_index[
+					movement_slot(state,viewport_visual_layer::center,x,y)];
+				if(slot<0)continue;
+				const movementst &movement=state.movements[size_t(slot)];
+				if(companion==nullptr)companion=&movement;
+				else if(!same_companion(*companion,movement))return {};
+				}
+		if(companion!=nullptr)
+			return companion_movement(
+				*companion,target_x,target_y,movement_progress(*companion));
+		return {};
+		}
+
 	visual_movement_idst allocate_movement_id()
 		{
 		const visual_movement_idst id=next_movement_id++;
@@ -599,12 +755,22 @@ class visual_animation_managerst
 			if(input.viewport==nullptr)return;
 			viewport_animationst &state=get_viewport(input);
 			state.seen=true;
+			synchronize(state,input);
+			index_movements(state);
+			}
+
+	private:
+		void synchronize(
+			viewport_animationst &state,
+			const viewport_visual_animation_inputst &input)
+			{
 
 			if(!input.valid())
 				{
 				reset_tracking(state);
 				state.has_context=false;
 				state.has_mirrored=false;
+				state.mirrored_tiles.clear();
 				return;
 				}
 
@@ -653,6 +819,7 @@ class visual_animation_managerst
 					size_t(input.dim_x)*size_t(input.dim_y),
 					int8_t(native_sprite_facing));
 				state.has_mirrored=false;
+				state.mirrored_tiles.clear();
 				}
 			// This hook runs per frame; the viewport is recomputed only when it changes, and while
 			// paused hardly at all. Re-reading a landed scroll steps every sprite by a tile.
@@ -666,6 +833,7 @@ class visual_animation_managerst
 				{
 				// Skips the recompute sweep, so clear has_mirrored here or a stale true survives.
 				state.has_mirrored=false;
+				state.mirrored_tiles.clear();
 				reset_tracking(state);
 				// window_z, zoom and resize change at input time; the buffers cross later.
 				// This reset covers only the input frame, not the crossing itself.
@@ -1058,18 +1226,24 @@ class visual_animation_managerst
 					input.current[static_cast<size_t>(
 						viewport_visual_layer::center)];
 				bool any_mirrored=false;
+				state.mirrored_tiles.clear();
 				for(size_t i=0;i<state.facing.size();++i)
 					{
 					if(center_current[i]==0)
 						state.facing[i]=int8_t(native_sprite_facing);
 					else if(state.facing[i]!=int8_t(native_sprite_facing))
+						{
 						any_mirrored=true;
+						state.mirrored_tiles.push_back(int32_t(i));
+						}
 					}
 				state.has_mirrored=any_mirrored;
 				}
 			for(const movementst &movement:state.movements)
 				if(movement_active(movement))force_full_redraw=true;
 			}
+
+	public:
 
 		void end_frame()
 			{
@@ -1089,7 +1263,11 @@ class visual_animation_managerst
 		// Pausing keeps persistent facing, but drops every in-flight visual transition.
 		void cancel_transitions()
 			{
-			for(viewport_animationst &state:viewports)reset_tracking(state);
+			for(viewport_animationst &state:viewports)
+				{
+				reset_tracking(state);
+				index_movements(state);
+				}
 			force_full_redraw=false;
 			}
 
@@ -1177,52 +1355,50 @@ class visual_animation_managerst
 			for(const viewport_animationst &state:viewports)
 				{
 				if(state.viewport!=viewport)continue;
-				const movementst *companion=nullptr;
-				bool ambiguous=false;
+				if(state.movement_index_ambiguous||state.movement_index.empty()||
+					!inside_viewport(state,target_x,target_y))
+					return scan_movement(state,layer,target_x,target_y);
+				return indexed_movement(state,layer,target_x,target_y);
+				}
+			return {};
+			}
+
+		// Appends every tile where get_movement can be active this frame: the target of each
+		// active movement, plus the 3x3 around each active center target for the companion
+		// rule. Unordered; a tile can appear more than once.
+		void active_movement_tiles(const void *viewport,std::vector<int32_t> &tiles) const
+			{
+			for(const viewport_animationst &state:viewports)
+				{
+				if(state.viewport!=viewport)continue;
 				for(const movementst &movement:state.movements)
 					{
 					if(!movement_active(movement))continue;
-					if(movement.layer==layer&&movement.target_x==target_x&&
-						movement.target_y==target_y)
+					if(movement.layer!=viewport_visual_layer::center)
 						{
-						return {
-							true,
-							movement.source_x,
-							movement.source_y,
-							movement_progress(movement),
-							false,
-							movement.id
-							};
+						if(inside_viewport(state,movement.target_x,movement.target_y))
+							tiles.push_back(movement.target_x*state.dim_y+movement.target_y);
+						continue;
 						}
-					if(layer==viewport_visual_layer::vehicle||
-						layer==viewport_visual_layer::center||
-						movement.layer!=viewport_visual_layer::center||
-						std::abs(movement.target_x-target_x)>1||
-						std::abs(movement.target_y-target_y)>1)continue;
-					if(companion!=nullptr&&
-						(companion->source_x-companion->target_x!=
-							movement.source_x-movement.target_x||
-						companion->source_y-companion->target_y!=
-							movement.source_y-movement.target_y||
-						companion->start_time_ms!=movement.start_time_ms||
-						companion->duration_ms!=movement.duration_ms))
-						ambiguous=true;
-					else if(companion==nullptr)
-						companion=&movement;
+					for(int32_t dx=-1;dx<=1;++dx)
+						for(int32_t dy=-1;dy<=1;++dy)
+							{
+							const int32_t x=movement.target_x+dx;
+							const int32_t y=movement.target_y+dy;
+							if(inside_viewport(state,x,y))tiles.push_back(x*state.dim_y+y);
+							}
 					}
-				if(ambiguous)return {};
-				if(companion!=nullptr)
-					return {
-						true,
-						target_x+companion->source_x-companion->target_x,
-						target_y+companion->source_y-companion->target_y,
-						movement_progress(*companion),
-						true,
-						companion->id
-						};
 				break;
 				}
-			return {};
+			}
+
+		// Tiles whose facing is mirrored, as tile indices in ascending order.
+		const std::vector<int32_t> &mirrored_tiles(const void *viewport) const
+			{
+			static const std::vector<int32_t> none;
+			for(const viewport_animationst &state:viewports)
+				if(state.viewport==viewport)return state.mirrored_tiles;
+			return none;
 			}
 };
 


### PR DESCRIPTION
Part of the speed series in #20, second series. Depends on PR 4 (#25).

## What we get

One set, its clears on every context change, the pan tracking that only existed to discard it, and one blank-and-repaint pass fewer per frame. Net −27 lines. Harness repaints per busy frame 5396 → 5262 (the scene's sprites move slowly, so last frame's tiles mostly overlap this frame's; the gain is larger on fast scenes).

## Why we need it

The engine repaints every viewport tile each frame before the hook runs, so a tile a sprite covered the frame before is already clean when the hook gets to it. The plugin still remembered last frame's coverage, blanked it and repainted it through the engine again, which is redundant with that repaint. Only the tiles this frame's sprites touch need blanking.

## Assumption

That every viewport tile is repainted by the engine each frame before `update_all` reaches the hook. Measured on my fork's build (one `update_viewport_tile` per tile per frame with nothing changed), same engine; not re-measured on this branch. If a code path exists where the engine skips resting tiles, a sprite could linger one frame; a paused fortress with a mirrored creature is the case to look at.

## What changes on screen

Fewer operations, same picture. Oracle over 1872 harness frames: every cell this build paints receives exactly the same operations as PR 4 (357714 cell-frames), and the 18363 dropped cell-frames carry only a blank-out fill and engine repaints, never a sprite. A sabotaged build that skips half its world repaints fails the oracle (19040 violations).

https://claude.ai/code/session_01W4Y5M6jkn8uAyLvzkX8spN
